### PR TITLE
Add a viewId parameter to the MarkdownText composable

### DIFF
--- a/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/MarkdownText.kt
+++ b/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/MarkdownText.kt
@@ -5,6 +5,7 @@ import android.util.TypedValue
 import android.view.View
 import android.widget.TextView
 import androidx.annotation.FontRes
+import androidx.annotation.IdRes
 import androidx.compose.material.LocalContentAlpha
 import androidx.compose.material.LocalContentColor
 import androidx.compose.material.LocalTextStyle
@@ -38,7 +39,8 @@ fun MarkdownText(
     textAlign: TextAlign? = null,
     maxLines: Int = Int.MAX_VALUE,
     @FontRes fontResource: Int? = null,
-    style: TextStyle = LocalTextStyle.current
+    style: TextStyle = LocalTextStyle.current,
+    @IdRes viewId: Int? = null
 ) {
     val textColor = color.takeOrElse {
         style.color.takeOrElse {
@@ -59,6 +61,9 @@ fun MarkdownText(
         setTextColor(textColor.toArgb())
         setMaxLines(maxLines)
         setTextSize(TypedValue.COMPLEX_UNIT_DIP, mergedStyle.fontSize.value)
+        viewId?.let{
+            setId(viewId)
+        }
         when (textAlign) {
             TextAlign.Left, TextAlign.Start -> View.TEXT_ALIGNMENT_TEXT_START
             TextAlign.Right, TextAlign.End -> View.TEXT_ALIGNMENT_TEXT_END

--- a/sample/src/main/java/dev/jeziellago/compose/markdown/MainActivity.kt
+++ b/sample/src/main/java/dev/jeziellago/compose/markdown/MainActivity.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.Card
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import dev.jeziellago.compose.markdowntext.MarkdownText
 
@@ -31,7 +30,7 @@ class MainActivity : AppCompatActivity() {
                 modifier = Modifier.padding(8.dp)
             ) {
                 item {
-                    MarkdownText(markdown = demo)
+                    MarkdownText(markdown = demo, viewId = R.id.markdownTextId)
                 }
             }
         }

--- a/sample/src/main/res/values/ids.xml
+++ b/sample/src/main/res/values/ids.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <item name="markdownTextId" type="id"/>
+</resources>


### PR DESCRIPTION
Add a viewId parameter to the MarkdownText composable.
viewId will be assigned to the underlying Android view TextView so that it can be found by espresso in tests.
