### PR TITLE
Only set LinkResolver if the client explicitly requests to handle link clicks

### DIFF
--- a/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/MarkdownText.kt
+++ b/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/MarkdownText.kt
@@ -157,11 +157,16 @@ private fun createMarkdownRender(
         .usePlugin(StrikethroughPlugin.create())
         .usePlugin(TablePlugin.create(context))
         .usePlugin(LinkifyPlugin.create())
-        .usePlugin(object: AbstractMarkwonPlugin() {
+        .usePlugin(object : AbstractMarkwonPlugin() {
             override fun configureConfiguration(builder: MarkwonConfiguration.Builder) {
-                builder.linkResolver { view, link ->
+                // Setting [MarkwonConfiguration.Builder.linkResolver] overrides
+                // Markwon's default behaviour - see Markwon's [LinkResolverDef]
+                // and how it's used in [MarkwonConfiguration.Builder].
+                // Only use it if the client explicitly wants to handle link clicks.
+                onLinkClicked ?: return
+                builder.linkResolver { _, link ->
                     // handle individual clicks on Textview link
-                    onLinkClicked?.invoke(link)
+                    onLinkClicked.invoke(link)
                 }
             }
         })


### PR DESCRIPTION
#### Description

Having markdown text like:

```
Click [here](https://something.con/)
```
And usage like:
```
MarkdownText(markdown = ...)
```
styles the link correctly, but does nothing when the link is clicked. Passing in `onLinkClicked` does trigger the callback:
```
MarkdownText(
    markdown = ...,
    onLinkClicked = { link -> println(...) }
)
``` 
but there's no default handling for the web url click.

#### Solution

Setting `MarkwonConfiguration.Builder.linkResolver` overrides [Markwon's](https://github.com/noties/Markwon) default behaviour - see [LinkResolverDef](https://github.com/noties/Markwon/blob/master/markwon-core/src/main/java/io/noties/markwon/LinkResolverDef.java) and how it's used in [MarkwonConfiguration.Builder](https://github.com/noties/Markwon/blob/master/markwon-core/src/main/java/io/noties/markwon/MarkwonConfiguration.java#L156-L158). Proposed solution is to only configure a `linkResolver` if the client explicitly requests to handle link clicks i.e. when they pass in `onLinkClicked`.

**Note**: I believe this partially fixes https://github.com/jeziellago/compose-markdown/issues/46 