### PR TITLE
Change coil dependency to api

### DIFF
--- a/markdowntext/build.gradle
+++ b/markdowntext/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     // TODO: Change it after migrating markwon project
     implementation "com.github.jeziellago:Markwon:58aa5aba6a"
 
-    implementation("io.coil-kt:coil:2.2.2")
+    api("io.coil-kt:coil:2.2.2")
 
     // Jetpack Compose
     implementation "androidx.compose.ui:ui:$compose_version"

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -48,8 +48,6 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 
-    implementation("io.coil-kt:coil:2.2.2")
-
     // Jetpack Compose
     implementation "androidx.lifecycle:lifecycle-viewmodel-compose:2.4.1"
     implementation "androidx.activity:activity-compose:1.4.0"
@@ -62,6 +60,5 @@ dependencies {
     implementation "androidx.compose.material:material-icons-extended:$compose_version"
     implementation "androidx.compose.runtime:runtime-livedata:$compose_version"
     implementation "androidx.compose.runtime:runtime-rxjava2:$compose_version"
-//    implementation project(':markdowntext')
-    implementation 'com.github.jeziellago:compose-markdown:4a84871586'
+    implementation project(':markdowntext')
 }


### PR DESCRIPTION
Coil types are used in public methods, so it should be an `api`
dependency

From [Gradle docs](https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_recognizing_dependencies):
> So when should you use the `api` configuration? ...
> \[When dependency contains] types used in public method parameters, ...

Should fix #31
