### PR TITLE
Disable jetifier

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,8 +15,6 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 # Android operating system, and which are packaged with your app"s APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
-# Automatically convert third-party libraries to use AndroidX
-android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 android.disableAutomaticComponentCreation=false


### PR DESCRIPTION
No dependencies use support library, so jetifier can be safely disabled

Checked by running ./gradlew checkJetifier
