### PR TITLE
Respect line height in typography style that is passed in. Also use correct SP unit for text size.

### DIFF
--- a/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/MarkdownText.kt
+++ b/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/MarkdownText.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.content.res.ResourcesCompat
+import androidx.core.widget.TextViewCompat
 import coil.ImageLoader
 import io.noties.markwon.AbstractMarkwonPlugin
 import io.noties.markwon.Markwon
@@ -114,8 +115,19 @@ private fun createTextView(
     return TextView(context).apply {
         onClick?.let { setOnClickListener { onClick() } }
         setTextColor(textColor.toArgb())
+        when {
+            style.lineHeight.isSp ->
+                TextViewCompat.setLineHeight(
+                    this,
+                    TypedValue.applyDimension(
+                        TypedValue.COMPLEX_UNIT_SP,
+                        style.lineHeight.value,
+                        context.resources.displayMetrics
+                    ).toInt()
+                )
+        }
         setMaxLines(maxLines)
-        setTextSize(TypedValue.COMPLEX_UNIT_DIP, mergedStyle.fontSize.value)
+        setTextSize(TypedValue.COMPLEX_UNIT_SP, mergedStyle.fontSize.value)
 
         viewId?.let { id = viewId }
         textAlign?.let { align ->


### PR DESCRIPTION
Closes #17 and closes #41 respectively.

Only supports line height specified in SP, not EM. I wasn't sure of the correct calculation to apply for EMs -- I read https://stackoverflow.com/questions/69311233/android-compose-has-textsize-unit-em but that may be out of scope for this PR. Regardless, I tested this and it works great:

```kotlin
val appTypography = Typography(
...
    bodyMedium = TextStyle(
        fontFamily = appFontFamily,
        fontWeight = FontWeight.W400,
        fontSize = 16.sp,
        lineHeight = 24.sp,
    ),
...
)

MarkdownText(
        markdown = message.content,
        fontResource = R.font.soehne_buch,
        style = typography.bodyMedium // line height of 24sp is now respected
    )    
                
```