### PR TITLE
Added ability to define Linkify mask

### DIFF
--- a/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/MarkdownText.kt
+++ b/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/MarkdownText.kt
@@ -2,6 +2,7 @@ package dev.jeziellago.compose.markdowntext
 
 import android.content.Context
 import android.graphics.Paint
+import android.text.util.Linkify
 import android.util.TypedValue
 import android.view.View
 import android.widget.TextView
@@ -50,12 +51,13 @@ fun MarkdownText(
     // it also enable the parent view to receive the click event
     disableLinkMovementMethod: Boolean = false,
     imageLoader: ImageLoader? = null,
+    linkifyMask: Int = Linkify.EMAIL_ADDRESSES or Linkify.PHONE_NUMBERS or Linkify.WEB_URLS,
     onLinkClicked: ((String) -> Unit)? = null,
     onTextLayout: ((numLines: Int) -> Unit)? = null
 ) {
     val defaultColor: Color = LocalContentColor.current.copy(alpha = LocalContentAlpha.current)
     val context: Context = LocalContext.current
-    val markdownRender: Markwon = remember { createMarkdownRender(context, imageLoader, onLinkClicked) }
+    val markdownRender: Markwon = remember { createMarkdownRender(context, imageLoader, linkifyMask, onLinkClicked) }
     AndroidView(
         modifier = modifier,
         factory = { ctx ->
@@ -144,6 +146,7 @@ private fun createTextView(
 private fun createMarkdownRender(
     context: Context,
     imageLoader: ImageLoader?,
+    linkifyMask: Int,
     onLinkClicked: ((String) -> Unit)? = null
 ): Markwon {
     val coilImageLoader = imageLoader ?: ImageLoader.Builder(context)
@@ -156,7 +159,7 @@ private fun createMarkdownRender(
         .usePlugin(CoilImagesPlugin.create(context, coilImageLoader))
         .usePlugin(StrikethroughPlugin.create())
         .usePlugin(TablePlugin.create(context))
-        .usePlugin(LinkifyPlugin.create())
+        .usePlugin(LinkifyPlugin.create(linkifyMask))
         .usePlugin(object : AbstractMarkwonPlugin() {
             override fun configureConfiguration(builder: MarkwonConfiguration.Builder) {
                 // Setting [MarkwonConfiguration.Builder.linkResolver] overrides

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -62,6 +62,6 @@ dependencies {
     implementation "androidx.compose.material:material-icons-extended:$compose_version"
     implementation "androidx.compose.runtime:runtime-livedata:$compose_version"
     implementation "androidx.compose.runtime:runtime-rxjava2:$compose_version"
-//    implementation project(':markdowntext')
-    implementation 'com.github.jeziellago:compose-markdown:4a84871586'
+    implementation project(':markdowntext')
+//    implementation 'com.github.jeziellago:compose-markdown:4a84871586'
 }

--- a/sample/src/main/java/dev/jeziellago/compose/markdown/markdown.kt
+++ b/sample/src/main/java/dev/jeziellago/compose/markdown/markdown.kt
@@ -144,6 +144,10 @@ val demo = "---\n" +
         "\n" +
         "Autoconverted link https://github.com/nodeca/pica (enable linkify to see)\n" +
         "\n" +
+        "tel: (800) 555-1212\n" +
+        "\n" +
+        "e-mail: compose@markdwon.com\n" +
+        "\n" +
         "\n" +
         "## Images\n" +
         "\n" +


### PR DESCRIPTION
Linkify has the ability to define which links should be searched in the text, but the problem is that the library searches for all types of links, including phone numbers and emails. I have added the ability to filter it by defining a Linkify mask. 

Documentation: https://developer.android.com/reference/android/text/util/Linkify#constants_1