### PR TITLE
Migrate to material3

### DIFF
--- a/markdowntext/build.gradle
+++ b/markdowntext/build.gradle
@@ -56,7 +56,7 @@ dependencies {
 
     // Jetpack Compose
     implementation "androidx.compose.ui:ui:$compose_version"
-    implementation "androidx.compose.material3:material3:1.1.1"
+    implementation "androidx.compose.material3:material3:1.1.2"
 }
 
 afterEvaluate {

--- a/markdowntext/build.gradle
+++ b/markdowntext/build.gradle
@@ -56,7 +56,7 @@ dependencies {
 
     // Jetpack Compose
     implementation "androidx.compose.ui:ui:$compose_version"
-    implementation "androidx.compose.material:material:$compose_version"
+    implementation "androidx.compose.material3:material3:1.1.1"
 }
 
 afterEvaluate {

--- a/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/MarkdownText.kt
+++ b/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/MarkdownText.kt
@@ -13,9 +13,8 @@ import android.view.View
 import android.widget.TextView
 import androidx.annotation.FontRes
 import androidx.annotation.IdRes
-import androidx.compose.material.LocalContentAlpha
-import androidx.compose.material.LocalContentColor
-import androidx.compose.material.LocalTextStyle
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.LocalTextStyle
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -77,7 +76,7 @@ fun MarkdownText(
     onLinkClicked: ((String) -> Unit)? = null,
     onTextLayout: ((numLines: Int) -> Unit)? = null
 ) {
-    val defaultColor: Color = LocalContentColor.current.copy(alpha = LocalContentAlpha.current)
+    val defaultColor: Color = LocalContentColor.current
     val context: Context = LocalContext.current
     val markdownRender: Markwon =
         remember { createMarkdownRender(context, imageLoader, linkifyMask, onLinkClicked) }


### PR DESCRIPTION
Material3 is more widely used with compose. 

Another option is to remove the material dependency completely as it's only used for the color (set a default one)