### PR TITLE
[feat] Taking fontfamily from style if fontResource it's null

### DIFF
--- a/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/MarkdownText.kt
+++ b/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/MarkdownText.kt
@@ -143,6 +143,7 @@ private fun createTextView(
             fontSize = if (fontSize != TextUnit.Unspecified) fontSize else style.fontSize,
             textAlign = textAlign,
             lineHeight = if (lineHeight != TextUnit.Unspecified) lineHeight else style.lineHeight,
+            fontFamily = if (fontResource == null) style.fontFamily else null
         )
     )
     return TextView(context).apply {


### PR DESCRIPTION
If fontfamily is defined on the style that is passed by arguments, it takes it from this style, instead of having to pass the fontResource.