### PR TITLE
Remove extra line spacing

### DIFF
--- a/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/MarkdownText.kt
+++ b/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/MarkdownText.kt
@@ -151,7 +151,6 @@ fun MarkdownText(
                 applyTextColor(style.color.takeOrElse { defaultColor }.toArgb())
                 applyFontSize(style)
                 applyLineHeight(style)
-                applyLineSpacing(style)
                 applyTextDecoration(style)
 
                 with(style) {

--- a/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/TextAppearanceExt.kt
+++ b/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/TextAppearanceExt.kt
@@ -68,10 +68,6 @@ fun TextView.applyFontSize(textStyle: TextStyle) {
     setTextSize(TypedValue.COMPLEX_UNIT_SP, textStyle.fontSize.value)
 }
 
-fun TextView.applyLineSpacing(textStyle: TextStyle) {
-    setLineSpacing(textStyle.lineHeight.value, 1f)
-}
-
 fun TextView.applyTextDecoration(textStyle: TextStyle) {
     if (textStyle.textDecoration == TextDecoration.LineThrough) {
         paintFlags = Paint.STRIKE_THRU_TEXT_FLAG

--- a/sample/src/main/java/dev/jeziellago/compose/markdown/MainActivity.kt
+++ b/sample/src/main/java/dev/jeziellago/compose/markdown/MainActivity.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import dev.jeziellago.compose.markdowntext.MarkdownText
 import dev.jeziellago.compose.markdown.sample.R
 
@@ -36,12 +37,17 @@ class MainActivity : AppCompatActivity() {
                     markdown = """
                             ## Custom font
 
-                            This text is using OpenSans Regular.
+                            This text is using OpenSans Regular. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
                             
                             ---
                         
                         """.trimIndent(),
                     fontResource = R.font.opensans_regular,
+                    style = TextStyle(
+                        textAlign = TextAlign.Justify,
+                        lineHeight = 24.sp,
+                        fontSize = 18.sp
+                    )
                 )
             }
             item {


### PR DESCRIPTION
Closes #98 

The issue was caused by extra spaces added to each line by `applyLineSpacing`. When `setLineSpacing` was called in a `TextView`, `applyLineSpacing` added unnecessary extra spacing to every line. The code already calls `applyFontSize(style)` and `applyLineHeight(style)`, which together set the appropriate spacing between lines of text. Therefore, `applyLineSpacing` is redundant.

Additionally, the custom font sample was modified to demonstrate the fix.