### PR TITLE
Fix issue #100

### DIFF
--- a/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/TextAppearanceExt.kt
+++ b/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/TextAppearanceExt.kt
@@ -7,7 +7,7 @@ import android.os.Build
 import android.text.SpannableStringBuilder
 import android.text.Spanned
 import android.util.TypedValue
-import android.view.View
+import android.view.Gravity
 import android.widget.TextView
 import androidx.annotation.FontRes
 import androidx.compose.ui.text.TextStyle
@@ -92,11 +92,11 @@ fun TextView.applyLineHeight(textStyle: TextStyle) {
 }
 
 fun TextView.applyTextAlign(align: TextAlign) {
-    textAlignment = when (align) {
-        TextAlign.Left, TextAlign.Start -> View.TEXT_ALIGNMENT_TEXT_START
-        TextAlign.Right, TextAlign.End -> View.TEXT_ALIGNMENT_TEXT_END
-        TextAlign.Center -> View.TEXT_ALIGNMENT_CENTER
-        else -> View.TEXT_ALIGNMENT_TEXT_START
+    gravity = when (align) {
+        TextAlign.Left, TextAlign.Start -> Gravity.START
+        TextAlign.Right, TextAlign.End -> Gravity.END
+        TextAlign.Center -> Gravity.CENTER_HORIZONTAL
+        else -> Gravity.START
     }
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && align == TextAlign.Justify) {


### PR DESCRIPTION
Using gravity in `applyTextAlign` so text alignment from style works as expected. 
You can see text alignment works as expected with the update.

<img width="1322" alt="Screenshot 2024-06-27 at 4 03 14 PM" src="https://github.com/jeziellago/compose-markdown/assets/16285615/4b3b0e02-3263-4d55-9c7a-be087f23acab">
