### PR TITLE
Add config to disable link underline

### DIFF
--- a/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/LinkStyle.kt
+++ b/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/LinkStyle.kt
@@ -1,0 +1,12 @@
+package dev.jeziellago.compose.markdowntext
+
+import androidx.compose.ui.graphics.Color
+
+data class LinkStyle(
+    val disableUnderline: Boolean = false,
+    val color: Color = Color.Unspecified
+) {
+    companion object {
+        val Default = LinkStyle()
+    }
+}

--- a/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/MarkdownText.kt
+++ b/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/MarkdownText.kt
@@ -83,7 +83,8 @@ fun MarkdownText(
 fun MarkdownText(
     markdown: String,
     modifier: Modifier = Modifier,
-    linkColor: Color = Color.Unspecified,
+    linkStyle: LinkStyle = LinkStyle.Default,
+    linkColor: Color = linkStyle.color,
     truncateOnTextOverflow: Boolean = false,
     maxLines: Int = Int.MAX_VALUE,
     isTextSelectable: Boolean = false,
@@ -168,6 +169,9 @@ fun MarkdownText(
                 textView.post {
                     onTextLayout(textView.lineCount)
                 }
+            }
+            if (linkStyle.disableUnderline) {
+                textView.applyRemoveUrlUnderlines()
             }
             textView.maxLines = maxLines
         }

--- a/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/TextAppearanceExt.kt
+++ b/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/TextAppearanceExt.kt
@@ -4,8 +4,12 @@ import android.graphics.Paint
 import android.graphics.Typeface
 import android.graphics.text.LineBreaker
 import android.os.Build
+import android.text.Spannable
 import android.text.SpannableStringBuilder
 import android.text.Spanned
+import android.text.TextPaint
+import android.text.style.URLSpan
+import android.text.style.UnderlineSpan
 import android.util.TypedValue
 import android.view.View
 import android.widget.TextView
@@ -23,6 +27,7 @@ import androidx.compose.ui.text.font.SystemFontFamily
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.core.content.res.ResourcesCompat
+import androidx.core.text.getSpans
 import androidx.core.view.doOnNextLayout
 import androidx.core.widget.TextViewCompat
 
@@ -75,6 +80,21 @@ fun TextView.applyLineSpacing(textStyle: TextStyle) {
 fun TextView.applyTextDecoration(textStyle: TextStyle) {
     if (textStyle.textDecoration == TextDecoration.LineThrough) {
         paintFlags = Paint.STRIKE_THRU_TEXT_FLAG
+    }
+}
+
+fun TextView.applyRemoveUrlUnderlines() {
+    val noUnderlineSpan = object : UnderlineSpan() {
+        override fun updateDrawState(tp: TextPaint) {
+            tp.isUnderlineText = false
+        }
+    }
+    when (val text = this.text) {
+        is Spannable -> {
+            text.getSpans<URLSpan>(0, text.length).forEach { span ->
+                text.setSpan(noUnderlineSpan, text.getSpanStart(span), text.getSpanEnd(span), 0)
+            }
+        }
     }
 }
 

--- a/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/TextAppearanceExt.kt
+++ b/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/TextAppearanceExt.kt
@@ -85,8 +85,9 @@ fun TextView.applyTextDecoration(textStyle: TextStyle) {
 
 fun TextView.applyRemoveUrlUnderlines() {
     val noUnderlineSpan = object : UnderlineSpan() {
-        override fun updateDrawState(tp: TextPaint) {
-            tp.isUnderlineText = false
+        override fun updateDrawState(textPaint: TextPaint) {
+            textPaint.isUnderlineText = false
+            super.updateDrawState(textPaint)
         }
     }
     when (val text = this.text) {


### PR DESCRIPTION
Happy for feedback on the implementation

`linkColor` is duplicated, but should be backwards compatible 

Examples


  <img width="415" alt="Screenshot 2024-07-09 at 09 39 38" src="https://github.com/jeziellago/compose-markdown/assets/72880206/a9ee4804-d268-41e2-a309-cdc2ea047061">
  
  <img width="415" alt="Screenshot 2024-07-09 at 09 40 07" src="https://github.com/jeziellago/compose-markdown/assets/72880206/dd9134fe-4893-49bc-9c74-2a8e58363998">

