### PR TITLE
Conditionally apply clickable modifier 

### DIFF
--- a/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/MarkdownText.kt
+++ b/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/MarkdownText.kt
@@ -4,10 +4,8 @@ import android.content.Context
 import android.os.Build
 import android.text.method.LinkMovementMethod
 import android.text.util.Linkify
-import android.widget.TextView
 import androidx.annotation.FontRes
 import androidx.annotation.IdRes
-import androidx.appcompat.widget.AppCompatTextView
 import androidx.compose.foundation.clickable
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.LocalTextStyle
@@ -117,8 +115,13 @@ fun MarkdownText(
             )
         }
 
+    val androidViewModifier = if (onClick != null) {
+        Modifier.clickable { onClick() }.then(modifier)
+    } else {
+        modifier
+    }
     AndroidView(
-        modifier = Modifier.clickable { onClick?.let { it() } }.then(modifier),
+        modifier = androidViewModifier,
         factory = { factoryContext ->
 
             val linkTextColor = linkColor.takeOrElse { style.color.takeOrElse { defaultColor } }


### PR DESCRIPTION
This PR contains changes to conditionally apply clickable modifier based on the presence of onClick parameter. The goal is to suppress the ripple effect when the view is not clickable. This solves issue https://github.com/jeziellago/compose-markdown/issues/111.