### PR TITLE
Invert order to avoiding overriding font weight and style configuration

### DIFF
--- a/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/MarkdownText.kt
+++ b/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/MarkdownText.kt
@@ -119,9 +119,9 @@ fun MarkdownText(
 
                 with(style) {
                     applyTextAlign(textAlign)
+                    fontFamily?.let { applyFontFamily(it) }
                     fontStyle?.let { applyFontStyle(it) }
                     fontWeight?.let { applyFontWeight(it) }
-                    fontFamily?.let { applyFontFamily(it) }
                 }
             }
             markdownRender.setMarkdown(textView, markdown)


### PR DESCRIPTION
Invert the order we call the method applyFontFamily, otherwise everything that we configured on **fontStyle** and **fontWeight** will be ignored because when we resolve the font family we are not using the **fontStyle** and **fontWeight** to load.
