### PR TITLE
support custom `coilStore` and change `onLinkClicked`

### DIFF
--- a/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/MarkdownRender.kt
+++ b/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/MarkdownRender.kt
@@ -14,6 +14,7 @@ import dev.jeziellago.compose.markdowntext.plugins.core.MardownCorePlugin
 import dev.jeziellago.compose.markdowntext.plugins.image.ImagesPlugin
 import dev.jeziellago.compose.markdowntext.plugins.syntaxhighlight.SyntaxHighlightPlugin
 import io.noties.markwon.AbstractMarkwonPlugin
+import io.noties.markwon.LinkResolverDef
 import io.noties.markwon.Markwon
 import io.noties.markwon.MarkwonConfiguration
 import io.noties.markwon.SoftBreakAddsNewLinePlugin
@@ -38,7 +39,7 @@ internal object MarkdownRender {
         enableUnderlineForLink: Boolean,
         beforeSetMarkdown: ((TextView, Spanned) -> Unit)? = null,
         afterSetMarkdown: ((TextView) -> Unit)? = null,
-        onLinkClicked: ((String) -> Unit)? = null,
+        onLinkClicked: (String) -> Boolean = {false},
         style: TextStyle
     ): Markwon {
         val coilImageLoader = imageLoader ?: ImageLoader.Builder(context)
@@ -95,10 +96,13 @@ internal object MarkdownRender {
                     // Markwon's default behaviour - see Markwon's [LinkResolverDef]
                     // and how it's used in [MarkwonConfiguration.Builder].
                     // Only use it if the client explicitly wants to handle link clicks.
-                    onLinkClicked ?: return
-                    builder.linkResolver { _, link ->
+                    val defaultLinkResolver = LinkResolverDef()
+                    builder.linkResolver { view, link ->
                         // handle individual clicks on Textview link
-                        onLinkClicked.invoke(link)
+                        // if user's handler return false, will use default handler
+                        if(onLinkClicked(link).not()) {
+                            defaultLinkResolver.resolve(view, link)
+                        }
                     }
                 }
             })

--- a/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/MarkdownRender.kt
+++ b/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/MarkdownRender.kt
@@ -29,6 +29,7 @@ internal object MarkdownRender {
     fun create(
         context: Context,
         imageLoader: ImageLoader?,
+        coilStore: ImagesPlugin.CoilStore? = null,
         linkifyMask: Int,
         enableSoftBreakAddsNewLine: Boolean,
         syntaxHighlightColor: Color,
@@ -59,7 +60,7 @@ internal object MarkdownRender {
                 )
             )
             .usePlugin(HtmlPlugin.create())
-            .usePlugin(ImagesPlugin.create(context, coilImageLoader))
+            .usePlugin(ImagesPlugin.create(context, coilImageLoader, coilStore))
             .usePlugin(StrikethroughPlugin.create())
             .usePlugin(TablePlugin.create(context))
             .usePlugin(LinkifyPlugin.create(linkifyMask))

--- a/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/MarkdownText.kt
+++ b/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/MarkdownText.kt
@@ -26,6 +26,9 @@ import coil.ImageLoader
 import dev.jeziellago.compose.markdowntext.plugins.image.ImagesPlugin
 import io.noties.markwon.Markwon
 
+/**
+ * @param onLinkClicked handle the url and return a boolean indicated consumed, if return true, default url handler will not handle the link; if return false, default link handler will take it
+ */
 @Composable
 fun MarkdownText(
     markdown: String,
@@ -53,7 +56,7 @@ fun MarkdownText(
     importForAccessibility: Int = View.IMPORTANT_FOR_ACCESSIBILITY_AUTO,
     beforeSetMarkdown: ((TextView, Spanned) -> Unit)? = null,
     afterSetMarkdown: ((TextView) -> Unit)? = null,
-    onLinkClicked: ((String) -> Unit)? = null,
+    onLinkClicked: (String) -> Boolean = {false},
     onTextLayout: ((numLines: Int) -> Unit)? = null
 ) {
     val defaultColor: Color = LocalContentColor.current

--- a/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/MarkdownText.kt
+++ b/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/MarkdownText.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.widget.TextViewCompat
 import coil.ImageLoader
+import dev.jeziellago.compose.markdowntext.plugins.image.ImagesPlugin
 import io.noties.markwon.Markwon
 
 @Composable
@@ -42,6 +43,7 @@ fun MarkdownText(
     // it also enable the parent view to receive the click event
     disableLinkMovementMethod: Boolean = false,
     imageLoader: ImageLoader? = null,
+    coilStore: ImagesPlugin.CoilStore? = null,
     linkifyMask: Int = Linkify.EMAIL_ADDRESSES or Linkify.PHONE_NUMBERS or Linkify.WEB_URLS,
     enableSoftBreakAddsNewLine: Boolean = true,
     syntaxHighlightColor: Color = Color.LightGray,
@@ -61,6 +63,7 @@ fun MarkdownText(
             MarkdownRender.create(
                 context,
                 imageLoader,
+                coilStore,
                 linkifyMask,
                 enableSoftBreakAddsNewLine,
                 syntaxHighlightColor,

--- a/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/plugins/image/ImagesPlugin.kt
+++ b/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/plugins/image/ImagesPlugin.kt
@@ -47,8 +47,8 @@ class ImagesPlugin private constructor(
     companion object {
         private val cache: HashMap<AsyncDrawable, Disposable> = HashMap(2)
 
-        fun create(context: Context, imageLoader: ImageLoader): ImagesPlugin {
-            val coilStore = object : CoilStore {
+        fun create(context: Context, imageLoader: ImageLoader, coilStore: CoilStore?): ImagesPlugin {
+            val coilStore = coilStore ?: (object : CoilStore {
                 override fun load(drawable: AsyncDrawable): ImageRequest {
                     return ImageRequest.Builder(context)
                         .data(drawable.destination)
@@ -58,7 +58,8 @@ class ImagesPlugin private constructor(
                 override fun cancel(disposable: Disposable) {
                     disposable.dispose()
                 }
-            }
+            })
+
             return ImagesPlugin(imageLoader, coilStore)
         }
 


### PR DESCRIPTION
changes:
- support set custom `coilStore`, it can used for load image from relative path
- change `onLinkClicked`, make it return a boolean to indicate consumed, if return false, default link handler will handle the link.