### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: Android CI
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/jeziellago/compose-markdown/security/code-scanning/1](https://github.com/jeziellago/compose-markdown/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will explicitly set the permissions for the `GITHUB_TOKEN` to `contents: read`, which is sufficient for the workflow's operations. This change ensures that the workflow adheres to the principle of least privilege by restricting unnecessary write permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
