### PR TITLE
Allow text selection colors customization

### DIFF
--- a/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/MarkdownText.kt
+++ b/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/MarkdownText.kt
@@ -10,6 +10,7 @@ import android.widget.TextView
 import androidx.annotation.FontRes
 import androidx.annotation.IdRes
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.text.selection.TextSelectionColors
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.runtime.Composable
@@ -33,6 +34,7 @@ fun MarkdownText(
     truncateOnTextOverflow: Boolean = false,
     maxLines: Int = Int.MAX_VALUE,
     isTextSelectable: Boolean = false,
+    textSelectionColors: TextSelectionColors? = null,
     autoSizeConfig: AutoSizeConfig? = null,
     @FontRes fontResource: Int? = null,
     style: TextStyle = LocalTextStyle.current,
@@ -120,6 +122,7 @@ fun MarkdownText(
                 applyFontSize(style)
                 applyLineHeight(style)
                 applyTextDecoration(style)
+                textSelectionColors?.let { applyTextSelectionColors(it) }
 
                 with(style) {
                     applyTextAlign(textAlign)

--- a/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/TextAppearanceExt.kt
+++ b/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/TextAppearanceExt.kt
@@ -10,6 +10,8 @@ import android.util.TypedValue
 import android.view.Gravity
 import android.widget.TextView
 import androidx.annotation.FontRes
+import androidx.compose.foundation.text.selection.TextSelectionColors
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontSynthesis
@@ -22,6 +24,7 @@ import androidx.compose.ui.text.font.resolveAsTypeface
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.core.content.res.ResourcesCompat
+import androidx.core.graphics.drawable.DrawableCompat
 import androidx.core.view.doOnNextLayout
 import androidx.core.widget.TextViewCompat
 
@@ -97,6 +100,17 @@ fun TextView.applyTextAlign(align: TextAlign) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && align == TextAlign.Justify) {
         justificationMode = LineBreaker.JUSTIFICATION_MODE_INTER_WORD
     }
+}
+
+fun TextView.applyTextSelectionColors(textSelectionColors: TextSelectionColors) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        val handleColor = textSelectionColors.handleColor.toArgb()
+        textSelectHandleLeft?.let { DrawableCompat.setTint(it, handleColor) }
+        textSelectHandleRight?.let { DrawableCompat.setTint(it, handleColor) }
+        textSelectHandle?.let { DrawableCompat.setTint(it, handleColor) }
+    }
+
+    highlightColor = textSelectionColors.backgroundColor.toArgb()
 }
 
 fun TextView.enableTextOverflow() {


### PR DESCRIPTION
This PR allows to update the text selection background and the handle colors when the text is selectable.

The recommended Compose way of doing so (using a `CompositionLocalProvider`) cannot work (probably because the markdown rendering view is a native Android View). Using the theme color `colorSecondary` is working but also modifies all control colors, and is not the way compose is edging towards.

_N.B. Handle color is only changed for target 29 and above (Android 10 / Q) as the method to access it programatically does not exist beforehand._