### PR TITLE
fix: crash when selecting text

### DIFF
--- a/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/CustomTextView.kt
+++ b/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/CustomTextView.kt
@@ -32,7 +32,9 @@ class CustomTextView(context: Context) : AppCompatTextView(context) {
 
     override fun dispatchTouchEvent(event: MotionEvent?): Boolean {
         if (selectionStart < 0 || selectionEnd < 0) {
-            Selection.setSelection(text as Spannable, text.length)
+            (text as? Spannable)?.let {
+                Selection.setSelection(it, it.length)
+            }
         } else if (selectionStart != selectionEnd) {
             if (event?.actionMasked == MotionEvent.ACTION_DOWN) {
                 val text = getText()


### PR DESCRIPTION
# Issue

App crashes when selecting text.

Details:

- OS: Android 11
- Device: Xiaomi Redmi Note 8 Pro
- Evidence: [Crash Video](https://github.com/user-attachments/assets/0eaa7d13-f7f0-4a14-b25a-ef409785522b)
- Error Log:

```
Process: dev.jeziellago.compose.markdown, PID: 18672
java.lang.IndexOutOfBoundsException: setSpan (-1 ... -1) starts before 0
at android.text.SpannableStringInternal.checkRange(SpannableStringInternal.java:497)
at android.text.SpannableStringInternal.setSpan(SpannableStringInternal.java:197)
at android.text.SpannableStringInternal.setSpan(SpannableStringInternal.java:184)
at android.text.SpannableString.setSpan(SpannableString.java:60)
at android.text.Selection.setSelection(Selection.java:96)
at android.text.Selection.setSelection(Selection.java:78)
at android.widget.Editor$SelectionStartHandleView.updateSelection(Editor.java:7712)
at android.widget.Editor$HandleView.positionAtCursorOffset(Editor.java:6937)
at android.widget.Editor$HandleView.updatePosition(Editor.java:6971)
at android.widget.Editor$PositionListener.onPreDraw(Editor.java:3701)
at android.view.ViewTreeObserver.dispatchOnPreDraw(ViewTreeObserver.java:1093)
at android.view.ViewRootImpl.performTraversals(ViewRootImpl.java:3325)
at android.view.ViewRootImpl.doTraversal(ViewRootImpl.java:2135)
at android.view.ViewRootImpl$TraversalRunnable.run(ViewRootImpl.java:8624)
at android.view.Choreographer$CallbackRecord.run(Choreographer.java:975)
at android.view.Choreographer.doCallbacks(Choreographer.java:799)
at android.view.Choreographer.doFrame(Choreographer.java:734)
at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:960)
at android.os.Handler.handleCallback(Handler.java:938)
at android.os.Handler.dispatchMessage(Handler.java:99)
at android.os.Looper.loop(Looper.java:236)
at android.app.ActivityThread.main(ActivityThread.java:8057)
at java.lang.reflect.Method.invoke(Native Method)
at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:620)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1011)
```

# Root Cause

The crash occurs due to an IndexOutOfBoundsException when selecting text in a TextView.
This issue is related to an Android platform bug affecting text selection in specific cases.

Reference: [Stack Overflow – Error when selecting text from TextView (IndexOutOfBoundsException)](https://stackoverflow.com/questions/22810147/error-when-selecting-text-from-textview-java-lang-indexoutofboundsexception-se)

# Verification
- Tested on Android 11 – Xiaomi Redmi Note 8 Pro
- Text selection now works without crash
- No regression observed on other Android versions