### PR TITLE
Fix links inside Markdown tables

### DIFF
--- a/markdowntext/src/androidTest/java/dev/jeziellago/compose/markdowntext/MarkdownComplexRenderingTest.kt
+++ b/markdowntext/src/androidTest/java/dev/jeziellago/compose/markdowntext/MarkdownComplexRenderingTest.kt
@@ -269,26 +269,16 @@ class MarkdownComplexRenderingTest {
         composeTestRule.onNodeWithTag("table_link_tap").assertExists()
         composeTestRule.waitForIdle()
 
-        // waitForIdle() only waits for Compose to settle; the embedded AndroidView may still be
-        // in its measure/layout pass on slower CI emulators. Wait until the TextView is fully
-        // laid out AND drawn so that TableRowSpan.cellWidth() (set inside draw()) is non-zero,
-        // which is required for cell-count calculation in tapTableLink to be correct.
-        // ActivityLifecycleMonitorRegistry requires the main thread, so everything goes inside
-        // runOnMainSync; isReady is written from main and read from the test thread after sync.
         composeTestRule.waitUntil(timeoutMillis = 5_000) {
-            // getCurrentActivity() uses ActivityLifecycleMonitorRegistry which must be
-            // called on the instrumentation thread, not the main thread.
-            val activity = getCurrentActivity() ?: return@waitUntil false
             var isReady = false
             InstrumentationRegistry.getInstrumentation().runOnMainSync {
+                val activity = getCurrentActivity() ?: return@runOnMainSync
                 val tv = findTextViews(activity.window.decorView)
                     .filterIsInstance<CustomTextView>()
                     .firstOrNull { it.text.toString().contains("Table callback test") }
                 if (tv != null && tv.width > 0 && tv.layout != null) {
                     val spannable = tv.text as? Spannable
                     val rowSpans = spannable?.getSpans(0, spannable.length, TableRowSpan::class.java)
-                    // cellWidth() is derived from TableRowSpan.width which is set in draw();
-                    // a value of 0 means the span has not yet been painted.
                     isReady = rowSpans != null && rowSpans.isNotEmpty() && rowSpans.all { it.cellWidth() > 0 }
                 }
             }

--- a/markdowntext/src/androidTest/java/dev/jeziellago/compose/markdowntext/MarkdownComplexRenderingTest.kt
+++ b/markdowntext/src/androidTest/java/dev/jeziellago/compose/markdowntext/MarkdownComplexRenderingTest.kt
@@ -4,7 +4,9 @@ import android.app.Activity
 import android.graphics.Paint
 import android.graphics.drawable.Drawable
 import android.text.Spannable
+import android.text.Spanned
 import android.text.style.*
+import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
@@ -31,6 +33,7 @@ import androidx.test.runner.lifecycle.Stage
 import androidx.test.platform.app.InstrumentationRegistry
 import coil3.ImageLoader
 import coil3.request.crossfade
+import io.noties.markwon.ext.tables.TableRowSpan
 import org.hamcrest.Description
 import org.hamcrest.Matcher
 import org.hamcrest.Matchers.allOf
@@ -212,6 +215,66 @@ class MarkdownComplexRenderingTest {
                 isDisplayed(),
                 hasClickableSpans()
             )))
+    }
+
+    @Test
+    fun testRegularLinkTapInvokesCallback() {
+        val markdown = """
+            Regular callback link: [Regular Link](https://regular-link.test)
+        """.trimIndent()
+        var clickedLink = ""
+
+        composeTestRule.setContent {
+            MaterialTheme {
+                MarkdownText(
+                    markdown = markdown,
+                    modifier = Modifier.testTag("regular_link_tap"),
+                    onLinkClicked = { url -> clickedLink = url }
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("regular_link_tap").assertExists()
+        composeTestRule.waitForIdle()
+
+        composeTestRule.runOnIdle {
+            val textView = requireTextViewContaining("Regular callback link:")
+            tapRegularLink(textView, "Regular Link")
+        }
+
+        assert(clickedLink == "https://regular-link.test")
+    }
+
+    @Test
+    fun testTableLinkTapInvokesCallback() {
+        val markdown = """
+            Table callback test
+            
+            | Name | Link |
+            |---|---|
+            | Item | [Table Link](https://table-link.test) |
+        """.trimIndent()
+        var clickedLink = ""
+
+        composeTestRule.setContent {
+            MaterialTheme {
+                MarkdownText(
+                    markdown = markdown,
+                    modifier = Modifier.testTag("table_link_tap"),
+                    onLinkClicked = { url -> clickedLink = url }
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("table_link_tap").assertExists()
+        composeTestRule.waitForIdle()
+
+        composeTestRule.runOnIdle {
+            val textView = requireTextViewContaining("Table callback test")
+            tapTableLink(textView, "Table Link")
+        }
+
+        assert(clickedLink == "https://table-link.test")
     }
 
     @Test
@@ -853,5 +916,96 @@ class MarkdownComplexRenderingTest {
             textViews += findTextViews(root.getChildAt(index))
         }
         return textViews
+    }
+
+    private fun requireTextViewContaining(text: String): CustomTextView {
+        val activity = checkNotNull(getCurrentActivity()) {
+            "No resumed activity found"
+        }
+
+        val textView = findTextViews(activity.window.decorView)
+            .filterIsInstance<CustomTextView>()
+            .firstOrNull { it.text.toString().contains(text) }
+
+        return checkNotNull(textView) {
+            "No CustomTextView found containing: $text"
+        }
+    }
+
+    private fun tapRegularLink(textView: CustomTextView, linkText: String) {
+        val spannable = textView.text as? Spannable
+            ?: error("Text is not spannable for regular link tap")
+        val layout = checkNotNull(textView.layout) { "TextView layout is null for regular link tap" }
+
+        val targetSpan = spannable.getSpans(0, spannable.length, ClickableSpan::class.java)
+            .firstOrNull { span ->
+                val start = spannable.getSpanStart(span)
+                val end = spannable.getSpanEnd(span)
+                start in 0..<end && spannable.subSequence(start, end).toString() == linkText
+            } ?: error("No clickable span found for regular link text: $linkText")
+
+        val start = spannable.getSpanStart(targetSpan)
+        val end = spannable.getSpanEnd(targetSpan)
+        val offset = start + ((end - start) / 2)
+        val line = layout.getLineForOffset(offset)
+        val x = layout.getPrimaryHorizontal(offset) + textView.totalPaddingLeft
+        val y = (layout.getLineTop(line) + layout.getLineBottom(line)) / 2f + textView.totalPaddingTop
+
+        tapAt(textView, x, y)
+    }
+
+    private fun tapTableLink(textView: CustomTextView, linkText: String) {
+        val spannable = textView.text as? Spannable
+            ?: error("Text is not spannable for table link tap")
+        val layout = checkNotNull(textView.layout) { "TextView layout is null for table link tap" }
+        val rowSpans = spannable.getSpans(0, spannable.length, TableRowSpan::class.java)
+        val contentWidth = textView.width - textView.totalPaddingLeft - textView.totalPaddingRight
+
+        for (rowSpan in rowSpans) {
+            val outerSpanStart = spannable.getSpanStart(rowSpan)
+            if (outerSpanStart < 0) continue
+            val outerLine = layout.getLineForOffset(outerSpanStart)
+            val cellWidth = rowSpan.cellWidth()
+            if (cellWidth <= 0) continue
+
+            val cells = (contentWidth / cellWidth).coerceAtLeast(1)
+            for (cellIndex in 0 until cells) {
+                val probeX = cellIndex * cellWidth + cellWidth / 2
+                val rowLayout = rowSpan.findLayoutForHorizontalOffset(probeX) ?: continue
+                val rowText = rowLayout.text as? Spanned ?: continue
+                val targetSpan = rowText.getSpans(0, rowText.length, ClickableSpan::class.java)
+                    .firstOrNull { span ->
+                        val start = rowText.getSpanStart(span)
+                        val end = rowText.getSpanEnd(span)
+                        start >= 0 && end > start && rowText.subSequence(start, end).toString() == linkText
+                    } ?: continue
+
+                val start = rowText.getSpanStart(targetSpan)
+                val end = rowText.getSpanEnd(targetSpan)
+                val rowOffset = start + ((end - start) / 2)
+                val rowLine = rowLayout.getLineForOffset(rowOffset)
+                val x = cellIndex * cellWidth + rowLayout.getPrimaryHorizontal(rowOffset) + textView.totalPaddingLeft
+                val y = layout.getLineTop(outerLine) +
+                    (rowLayout.getLineTop(rowLine) + rowLayout.getLineBottom(rowLine)) / 2f +
+                    textView.totalPaddingTop
+
+                tapAt(textView, x, y)
+                return
+            }
+        }
+
+        error("No clickable table span found for table link text: $linkText")
+    }
+
+    private fun tapAt(textView: CustomTextView, x: Float, y: Float) {
+        val down = MotionEvent.obtain(0L, 0L, MotionEvent.ACTION_DOWN, x, y, 0)
+        val up = MotionEvent.obtain(0L, 16L, MotionEvent.ACTION_UP, x, y, 0)
+        try {
+            textView.onTouchEvent(down)
+            textView.onTouchEvent(up)
+        } finally {
+            down.recycle()
+            up.recycle()
+        }
     }
 }

--- a/markdowntext/src/androidTest/java/dev/jeziellago/compose/markdowntext/MarkdownComplexRenderingTest.kt
+++ b/markdowntext/src/androidTest/java/dev/jeziellago/compose/markdowntext/MarkdownComplexRenderingTest.kt
@@ -269,6 +269,17 @@ class MarkdownComplexRenderingTest {
         composeTestRule.onNodeWithTag("table_link_tap").assertExists()
         composeTestRule.waitForIdle()
 
+        // waitForIdle() only waits for Compose to settle; the embedded AndroidView may still be
+        // in its measure/layout pass on slower CI emulators. Wait until the TextView is fully
+        // laid out (width > 0) so that cell-count calculation in tapTableLink is correct.
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            val activity = getCurrentActivity() ?: return@waitUntil false
+            val tv = findTextViews(activity.window.decorView)
+                .filterIsInstance<CustomTextView>()
+                .firstOrNull { it.text.toString().contains("Table callback test") }
+            tv != null && tv.width > 0 && tv.layout != null
+        }
+
         composeTestRule.runOnIdle {
             val textView = requireTextViewContaining("Table callback test")
             tapTableLink(textView, "Table Link")

--- a/markdowntext/src/androidTest/java/dev/jeziellago/compose/markdowntext/MarkdownComplexRenderingTest.kt
+++ b/markdowntext/src/androidTest/java/dev/jeziellago/compose/markdowntext/MarkdownComplexRenderingTest.kt
@@ -273,6 +273,8 @@ class MarkdownComplexRenderingTest {
         // in its measure/layout pass on slower CI emulators. Wait until the TextView is fully
         // laid out AND drawn so that TableRowSpan.cellWidth() (set inside draw()) is non-zero,
         // which is required for cell-count calculation in tapTableLink to be correct.
+        // ActivityLifecycleMonitorRegistry requires the main thread, so everything goes inside
+        // runOnMainSync; isReady is written from main and read from the test thread after sync.
         composeTestRule.waitUntil(timeoutMillis = 5_000) {
             // getCurrentActivity() uses ActivityLifecycleMonitorRegistry which must be
             // called on the instrumentation thread, not the main thread.

--- a/markdowntext/src/androidTest/java/dev/jeziellago/compose/markdowntext/MarkdownComplexRenderingTest.kt
+++ b/markdowntext/src/androidTest/java/dev/jeziellago/compose/markdowntext/MarkdownComplexRenderingTest.kt
@@ -975,7 +975,6 @@ class MarkdownComplexRenderingTest {
             ?: error("Text is not spannable for table link tap")
         val layout = checkNotNull(textView.layout) { "TextView layout is null for table link tap" }
         val rowSpans = spannable.getSpans(0, spannable.length, TableRowSpan::class.java)
-        val contentWidth = textView.width - textView.totalPaddingLeft - textView.totalPaddingRight
 
         for (rowSpan in rowSpans) {
             val outerSpanStart = spannable.getSpanStart(rowSpan)
@@ -984,29 +983,32 @@ class MarkdownComplexRenderingTest {
             val cellWidth = rowSpan.cellWidth()
             if (cellWidth <= 0) continue
 
-            val cells = (contentWidth / cellWidth).coerceAtLeast(1)
-            for (cellIndex in 0 until cells) {
+            var cellIndex = 0
+            while (true) {
                 val probeX = cellIndex * cellWidth + cellWidth / 2
-                val rowLayout = rowSpan.findLayoutForHorizontalOffset(probeX) ?: continue
-                val rowText = rowLayout.text as? Spanned ?: continue
-                val targetSpan = rowText.getSpans(0, rowText.length, ClickableSpan::class.java)
-                    .firstOrNull { span ->
-                        val start = rowText.getSpanStart(span)
-                        val end = rowText.getSpanEnd(span)
-                        start >= 0 && end > start && rowText.subSequence(start, end).toString() == linkText
-                    } ?: continue
-
-                val start = rowText.getSpanStart(targetSpan)
-                val end = rowText.getSpanEnd(targetSpan)
-                val rowOffset = start + ((end - start) / 2)
-                val rowLine = rowLayout.getLineForOffset(rowOffset)
-                val x = cellIndex * cellWidth + rowLayout.getPrimaryHorizontal(rowOffset) + textView.totalPaddingLeft
-                val y = layout.getLineTop(outerLine) +
-                    (rowLayout.getLineTop(rowLine) + rowLayout.getLineBottom(rowLine)) / 2f +
-                    textView.totalPaddingTop
-
-                tapAt(textView, x, y)
-                return
+                val rowLayout = rowSpan.findLayoutForHorizontalOffset(probeX) ?: break
+                val rowText = rowLayout.text as? Spanned
+                if (rowText != null) {
+                    val targetSpan = rowText.getSpans(0, rowText.length, ClickableSpan::class.java)
+                        .firstOrNull { span ->
+                            val start = rowText.getSpanStart(span)
+                            val end = rowText.getSpanEnd(span)
+                            start >= 0 && end > start && rowText.subSequence(start, end).toString() == linkText
+                        }
+                    if (targetSpan != null) {
+                        val start = rowText.getSpanStart(targetSpan)
+                        val end = rowText.getSpanEnd(targetSpan)
+                        val rowOffset = start + ((end - start) / 2)
+                        val rowLine = rowLayout.getLineForOffset(rowOffset)
+                        val x = cellIndex * cellWidth + rowLayout.getPrimaryHorizontal(rowOffset) + textView.totalPaddingLeft
+                        val y = layout.getLineTop(outerLine) +
+                            (rowLayout.getLineTop(rowLine) + rowLayout.getLineBottom(rowLine)) / 2f +
+                            textView.totalPaddingTop
+                        tapAt(textView, x, y)
+                        return
+                    }
+                }
+                cellIndex++
             }
         }
 

--- a/markdowntext/src/androidTest/java/dev/jeziellago/compose/markdowntext/MarkdownComplexRenderingTest.kt
+++ b/markdowntext/src/androidTest/java/dev/jeziellago/compose/markdowntext/MarkdownComplexRenderingTest.kt
@@ -271,13 +271,26 @@ class MarkdownComplexRenderingTest {
 
         // waitForIdle() only waits for Compose to settle; the embedded AndroidView may still be
         // in its measure/layout pass on slower CI emulators. Wait until the TextView is fully
-        // laid out (width > 0) so that cell-count calculation in tapTableLink is correct.
+        // laid out AND drawn so that TableRowSpan.cellWidth() (set inside draw()) is non-zero,
+        // which is required for cell-count calculation in tapTableLink to be correct.
         composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            // getCurrentActivity() uses ActivityLifecycleMonitorRegistry which must be
+            // called on the instrumentation thread, not the main thread.
             val activity = getCurrentActivity() ?: return@waitUntil false
-            val tv = findTextViews(activity.window.decorView)
-                .filterIsInstance<CustomTextView>()
-                .firstOrNull { it.text.toString().contains("Table callback test") }
-            tv != null && tv.width > 0 && tv.layout != null
+            var isReady = false
+            InstrumentationRegistry.getInstrumentation().runOnMainSync {
+                val tv = findTextViews(activity.window.decorView)
+                    .filterIsInstance<CustomTextView>()
+                    .firstOrNull { it.text.toString().contains("Table callback test") }
+                if (tv != null && tv.width > 0 && tv.layout != null) {
+                    val spannable = tv.text as? Spannable
+                    val rowSpans = spannable?.getSpans(0, spannable.length, TableRowSpan::class.java)
+                    // cellWidth() is derived from TableRowSpan.width which is set in draw();
+                    // a value of 0 means the span has not yet been painted.
+                    isReady = rowSpans != null && rowSpans.isNotEmpty() && rowSpans.all { it.cellWidth() > 0 }
+                }
+            }
+            isReady
         }
 
         composeTestRule.runOnIdle {

--- a/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/CustomTextView.kt
+++ b/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/CustomTextView.kt
@@ -6,6 +6,7 @@ import android.text.Layout
 import android.text.Selection
 import android.text.Spannable
 import android.text.SpannableString
+import android.text.Spanned
 import android.text.style.ClickableSpan
 import android.util.AttributeSet
 import android.view.MotionEvent
@@ -140,6 +141,7 @@ class CustomTextView : AppCompatTextView {
         ) {
             val link = getClickableSpans(event)
 
+            // FKZ 01
             if (link.isNotEmpty()) {
                 if (event.action == MotionEvent.ACTION_UP) {
                     link[0].onClick(this)
@@ -227,7 +229,39 @@ class CustomTextView : AppCompatTextView {
         val off = layout.getOffsetForHorizontal(line, x.toFloat())
 
         val spannable = text as? Spannable ?: return emptyArray()
-        return spannable.getSpans(off, off, ClickableSpan::class.java)
+        val directClickableSpans = spannable.getSpans(off, off, ClickableSpan::class.java)
+        if (directClickableSpans.isNotEmpty()) {
+            return directClickableSpans
+        }
+
+        // Table cells render clickable spans inside row-internal layouts.
+        val tableRowSpans = spannable.getSpans(off, off, TableRowSpan::class.java)
+        if (tableRowSpans.isEmpty()) {
+            return emptyArray()
+        }
+
+        val tableRowSpan = tableRowSpans[0]
+        val rowLayout = tableRowSpan.findLayoutForHorizontalOffset(x) ?: return emptyArray()
+        val rowY = layout.getLineTop(line)
+        val rowRelativeY = y - rowY
+        if (rowRelativeY < 0 || rowRelativeY >= rowLayout.height) {
+            return emptyArray()
+        }
+
+        val rowLine = rowLayout.getLineForVertical(rowRelativeY)
+        if (rowLine < 0 || rowLine >= rowLayout.lineCount) {
+            return emptyArray()
+        }
+
+        val cellWidth = tableRowSpan.cellWidth()
+        if (cellWidth <= 0) {
+            return emptyArray()
+        }
+
+        // Map touch coordinates into the tapped table cell layout.
+        val rowOff = rowLayout.getOffsetForHorizontal(rowLine, (x % cellWidth).toFloat())
+        val rowText = rowLayout.text as? Spanned ?: return emptyArray()
+        return rowText.getSpans(rowOff, rowOff, ClickableSpan::class.java)
     }
 
     override fun performClick(): Boolean {

--- a/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/CustomTextView.kt
+++ b/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/CustomTextView.kt
@@ -141,7 +141,6 @@ class CustomTextView : AppCompatTextView {
         ) {
             val link = getClickableSpans(event)
 
-            // FKZ 01
             if (link.isNotEmpty()) {
                 if (event.action == MotionEvent.ACTION_UP) {
                     link[0].onClick(this)

--- a/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/MarkdownText.kt
+++ b/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/MarkdownText.kt
@@ -3,7 +3,6 @@ package dev.jeziellago.compose.markdowntext
 import android.content.Context
 import android.os.Build
 import android.text.Spanned
-import android.text.method.LinkMovementMethod
 import android.text.util.Linkify
 import android.view.View
 import android.widget.TextView
@@ -26,6 +25,7 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.widget.TextViewCompat
 import coil3.ImageLoader
 import io.noties.markwon.Markwon
+import io.noties.markwon.ext.tables.TableAwareMovementMethod
 
 @Composable
 fun MarkdownText(
@@ -114,7 +114,7 @@ fun MarkdownText(
                     movementMethod = if (disableLinkMovementMethod) {
                         null
                     } else {
-                        LinkMovementMethod.getInstance()
+                        TableAwareMovementMethod.create()
                     }
 
                     if (truncateOnTextOverflow) enableTextOverflow()
@@ -136,7 +136,7 @@ fun MarkdownText(
                 // Clear previous state before rendering new content
                 // This prevents corruption when views are reused in LazyColumn
                 textView.resetTextState()
-                
+
                 with(textView) {
                     applyTextColor(style.color.takeOrElse { defaultColor }.toArgb())
                     applyFontSize(style)
@@ -159,7 +159,7 @@ fun MarkdownText(
                 textView.movementMethod = if (disableLinkMovementMethod) {
                     null
                 } else {
-                    LinkMovementMethod.getInstance()
+                    TableAwareMovementMethod.create()
                 }
                 if (onTextLayout != null) {
                     textView.post {

--- a/sample/src/main/java/dev/jeziellago/compose/markdown/MainActivity.kt
+++ b/sample/src/main/java/dev/jeziellago/compose/markdown/MainActivity.kt
@@ -289,16 +289,31 @@ private fun SampleMarkdown() {
                             | data   | path to data files to supply the data that will be passed into templates. |
                             | engine | engine to be used for processing templates. Handlebars is the default. |
                             | ext    | extension to be used for dest files. |
-                            
+                             
                             Right aligned columns
-                            
+                             
                             | Option | Description |
                             | ------:| -----------:|
                             | data   | path to data files to supply the data that will be passed into templates. |
                             | engine | engine to be used for processing templates. Handlebars is the default. |
                             | ext    | extension to be used for dest files. |
-                            
+                             
                         """.trimIndent(),
+                    )
+                }
+                item {
+                    MarkdownText(
+                        modifier = Modifier.fillMaxWidth(),
+                        markdown = """
+                            ## Table with Links
+
+                            | Framework | Repository | Documentation |
+                            |-----------|-----------|-----------------|
+                            | Kotlin | [GitHub](https://github.com/jetbrains/kotlin) | [Docs](https://kotlinlang.org) |
+                            | Compose | [GitHub](https://github.com/jetbrains/compose-jb) | [Docs](https://www.jetbrains.com/help/compose-multiplatform/) |
+                            | Android | [GitHub](https://github.com/android/android) | [Docs](https://developer.android.com) |
+                             
+                        """.trimIndent()
                     )
                 }
                 item {


### PR DESCRIPTION
# Summary

As reported at #153, links inside markdown tables are not working. The callback are not invoked when pressing these links.


# Solution

1. CustomTextView — Extended getClickableSpans() to fall back to table-row lookup: if no direct link is found, map touch coordinates into the tapped table cell's internal layout and resolve ClickableSpan there.
2. MarkdownText — Switched to TableAwareMovementMethod.create() instead of plain LinkMovementMethod for consistent table-aware behavior.
