### PR TITLE
Accessibility: adding flag to allow paragraph-by-paragraph reading wit…

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ fun BlockLevelAccessibility() {
 }
 ```
 
-When `enableBlockLevelAccessibility = true`, TalkBack focuses each block individually (heading, then each paragraph), making it easier for users to navigate long markdown documents.
+When `enableBlockLevelAccessibility = true`, TalkBack focuses each block individually, including headings, paragraphs, and table rows, making it easier for users to navigate long markdown documents.
 
 ## Sample App
 

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ fun BlockLevelAccessibility() {
 }
 ```
 
-When `enableBlockLevelAccessibility = true`, TalkBack focuses each block individually, including headings, paragraphs, and table rows, making it easier for users to navigate long markdown documents.
+When `enableBlockLevelAccessibility = true`, TalkBack focuses each block individually, including headings, paragraphs, and table cells. Links inside table cells are exposed as actionable nodes for both Markdown links and auto-linkified URLs.
 
 ## Sample App
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Some of the most useful parameters exposed by `MarkdownText`:
 - `enableSoftBreakAddsNewLine`: treat soft breaks as new lines
 - `headingBreakColor`: customize heading divider color
 - `enableUnderlineForLink`: turn link underlines on or off
+- `enableBlockLevelAccessibility`: expose virtual accessibility nodes per text block for TalkBack (default: false)
 - `onTextLayout`: observe rendered line count
 
 ## Advanced Example
@@ -179,6 +180,58 @@ fun InteractiveMarkdown() {
     )
 }
 ```
+
+## Accessibility: Block-Level TalkBack
+
+By default, TalkBack announces the entire markdown content as a single node. Enable `enableBlockLevelAccessibility` to expose individual text blocks (paragraphs, lists, code blocks, etc.) as separate accessibility nodes, allowing users to navigate and interact with specific blocks.
+
+### Example: Disabled (default behavior)
+
+```kotlin
+import androidx.compose.runtime.Composable
+import dev.jeziellago.compose.markdowntext.MarkdownText
+
+@Composable
+fun DefaultAccessibility() {
+    MarkdownText(
+        markdown = """
+            # Heading
+            
+            First paragraph with some content.
+            
+            Second paragraph with more details.
+            
+            Third paragraph to wrap up.
+        """.trimIndent(),
+        enableBlockLevelAccessibility = false  // TalkBack sees one big text node
+    )
+}
+```
+
+### Example: Enabled (block-level accessibility)
+
+```kotlin
+import androidx.compose.runtime.Composable
+import dev.jeziellago.compose.markdowntext.MarkdownText
+
+@Composable
+fun BlockLevelAccessibility() {
+    MarkdownText(
+        markdown = """
+            # Heading
+            
+            First paragraph with some content.
+            
+            Second paragraph with more details.
+            
+            Third paragraph to wrap up.
+        """.trimIndent(),
+        enableBlockLevelAccessibility = true  // TalkBack navigates each block separately
+    )
+}
+```
+
+When `enableBlockLevelAccessibility = true`, TalkBack focuses each block individually (heading, then each paragraph), making it easier for users to navigate long markdown documents.
 
 ## Sample App
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Apr 26 14:43:41 BRT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Apr 26 14:43:41 BRT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/CustomTextView.kt
+++ b/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/CustomTextView.kt
@@ -2,6 +2,7 @@ package dev.jeziellago.compose.markdowntext
 
 import android.content.Context
 import android.graphics.Canvas
+import android.graphics.Rect
 import android.text.Layout
 import android.text.Selection
 import android.text.Spannable
@@ -9,12 +10,16 @@ import android.text.SpannableString
 import android.text.Spanned
 import android.text.style.ClickableSpan
 import android.util.AttributeSet
+import android.view.accessibility.AccessibilityEvent
 import android.view.MotionEvent
 import android.view.View.MeasureSpec
 import android.view.ViewConfiguration
 import androidx.appcompat.widget.AppCompatTextView
 import androidx.core.graphics.withTranslation
 import androidx.core.text.getSpans
+import androidx.core.view.ViewCompat
+import androidx.core.view.accessibility.AccessibilityNodeInfoCompat
+import androidx.customview.widget.ExploreByTouchHelper
 import io.noties.markwon.core.spans.BlockQuoteSpan
 import io.noties.markwon.core.spans.CodeBlockSpan
 import io.noties.markwon.ext.tables.TableRowSpan
@@ -46,6 +51,21 @@ class CustomTextView : AppCompatTextView {
     private var hasMoved = false
     private var didLongPress = false
     private var didPerformClickForCurrentGesture = false
+    private var isBlockLevelAccessibilityEnabled: Boolean = false
+    private var blockAccessibilityHelper: BlockAccessibilityHelper? = null
+
+    private data class AccessibilityBlock(
+        val id: Int,
+        val firstLine: Int,
+        val lastLine: Int,
+        val bounds: Rect,
+        val text: String,
+    )
+
+    init {
+        blockAccessibilityHelper = BlockAccessibilityHelper(this)
+        ViewCompat.setAccessibilityDelegate(this, blockAccessibilityHelper)
+    }
 
     constructor(context: Context) :
             super(context, null, android.R.attr.textViewStyle)
@@ -77,6 +97,10 @@ class CustomTextView : AppCompatTextView {
         val wrappedWidth = measuredWidth - uselessPaddingWidth
         val height = measuredHeight
         setMeasuredDimension(wrappedWidth, height)
+    }
+
+    override fun dispatchHoverEvent(event: MotionEvent): Boolean {
+        return (blockAccessibilityHelper?.dispatchHoverEvent(event) == true) || super.dispatchHoverEvent(event)
     }
 
     override fun onDraw(canvas: Canvas) {
@@ -181,6 +205,18 @@ class CustomTextView : AppCompatTextView {
         return super.dispatchTouchEvent(event)
     }
 
+    override fun onTextChanged(text: CharSequence?, start: Int, lengthBefore: Int, lengthAfter: Int) {
+        super.onTextChanged(text, start, lengthBefore, lengthAfter)
+        blockAccessibilityHelper?.invalidateRoot()
+    }
+
+    override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
+        super.onLayout(changed, left, top, right, bottom)
+        if (changed) {
+            blockAccessibilityHelper?.invalidateRoot()
+        }
+    }
+
     public override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
         // Clean up resources when view is recycled in LazyColumn
@@ -202,6 +238,7 @@ class CustomTextView : AppCompatTextView {
         text = ""
         removeAllSpans()
         lastMeasureWidth = -1
+        blockAccessibilityHelper?.invalidateRoot()
     }
 
     private fun getClickableSpans(event: MotionEvent): Array<ClickableSpan> {
@@ -282,10 +319,17 @@ class CustomTextView : AppCompatTextView {
 
     fun setOnBlockClickListener(listener: (() -> Unit)?) {
         onBlockClick = listener
+        blockAccessibilityHelper?.invalidateRoot()
     }
 
     fun setLinkClicksEnabled(enabled: Boolean) {
         areLinkClicksEnabled = enabled
+    }
+
+    fun setBlockLevelAccessibilityEnabled(enabled: Boolean) {
+        if (isBlockLevelAccessibilityEnabled == enabled) return
+        isBlockLevelAccessibilityEnabled = enabled
+        blockAccessibilityHelper?.invalidateRoot()
     }
 
     private fun getMaxLineWidth(layout: Layout): Float =
@@ -308,6 +352,175 @@ class CustomTextView : AppCompatTextView {
         val spannable = if (text is Spannable) text as Spannable else SpannableString(text)
         return spannable.getSpans<Any>(0, text.length).any {
             it is TableRowSpan || it is TableSpan || it is CodeBlockSpan || it is BlockQuoteSpan
+        }
+    }
+
+    private fun buildAccessibilityBlocks(): List<AccessibilityBlock> {
+        val layout = layout ?: return emptyList()
+        val content = text?.toString().orEmpty()
+        if (content.isBlank() || layout.lineCount == 0) return emptyList()
+
+        val blocks = mutableListOf<AccessibilityBlock>()
+        var runStartLine = -1
+        var runStartOffset = -1
+
+        fun isLineBlank(line: Int): Boolean {
+            val start = layout.getLineStart(line).coerceIn(0, content.length)
+            val end = layout.getLineEnd(line).coerceIn(0, content.length)
+            if (start >= end) return true
+            return content.substring(start, end).trim().isEmpty()
+        }
+
+        fun lineEndsWithExplicitNewline(line: Int): Boolean {
+            val end = layout.getLineEnd(line).coerceIn(0, content.length)
+            if (end <= 0) return false
+            return content[end - 1] == '\n'
+        }
+
+        fun closeRun(lastLine: Int, runEndOffset: Int) {
+            if (runStartLine == -1 || runStartOffset == -1) return
+            val safeEndOffset = runEndOffset.coerceIn(0, content.length)
+            val blockText = content.substring(runStartOffset.coerceIn(0, safeEndOffset), safeEndOffset).trim()
+            if (blockText.isBlank()) {
+                runStartLine = -1
+                runStartOffset = -1
+                return
+            }
+
+            val left = (totalPaddingLeft - scrollX).coerceAtLeast(0)
+            val right = (width - totalPaddingRight - scrollX).coerceAtLeast(left + 1)
+            val top = (totalPaddingTop + layout.getLineTop(runStartLine) - scrollY).coerceAtLeast(0)
+            val bottom = (totalPaddingTop + layout.getLineBottom(lastLine) - scrollY).coerceAtLeast(top + 1)
+
+            blocks += AccessibilityBlock(
+                id = blocks.size,
+                firstLine = runStartLine,
+                lastLine = lastLine,
+                bounds = Rect(left, top, right, bottom),
+                text = blockText,
+            )
+            runStartLine = -1
+            runStartOffset = -1
+        }
+
+        for (line in 0 until layout.lineCount) {
+            if (isLineBlank(line)) {
+                closeRun(
+                    lastLine = line - 1,
+                    runEndOffset = layout.getLineStart(line).coerceIn(0, content.length),
+                )
+                continue
+            }
+
+            if (runStartLine == -1) {
+                runStartLine = line
+                runStartOffset = layout.getLineStart(line).coerceIn(0, content.length)
+            }
+
+            if (lineEndsWithExplicitNewline(line) && line < layout.lineCount - 1) {
+                closeRun(
+                    lastLine = line,
+                    runEndOffset = layout.getLineEnd(line).coerceIn(0, content.length),
+                )
+            }
+        }
+
+        if (runStartLine != -1) {
+            val lastLine = layout.lineCount - 1
+            closeRun(
+                lastLine = lastLine,
+                runEndOffset = layout.getLineEnd(lastLine).coerceIn(0, content.length),
+            )
+        }
+
+        return blocks
+    }
+
+    private inner class BlockAccessibilityHelper(host: CustomTextView) : ExploreByTouchHelper(host) {
+
+        override fun onPopulateNodeForHost(node: AccessibilityNodeInfoCompat) {
+            super.onPopulateNodeForHost(node)
+            if (!isBlockLevelAccessibilityEnabled) {
+                return
+            }
+            // Keep host as a container so TalkBack traverses virtual block children instead of
+            // announcing one giant TextView node first.
+            node.text = null
+            node.contentDescription = null
+            node.className = android.view.View::class.java.name
+            node.isFocusable = false
+            node.isClickable = false
+            node.isScreenReaderFocusable = false
+        }
+
+        override fun getVirtualViewAt(x: Float, y: Float): Int {
+            if (!isBlockLevelAccessibilityEnabled) return INVALID_ID
+            if (x < 0f || y < 0f || x >= width.toFloat() || y >= height.toFloat()) {
+                return INVALID_ID
+            }
+
+            val layout = layout ?: return INVALID_ID
+            if (layout.height <= 0) return INVALID_ID
+
+            val blocks = buildAccessibilityBlocks()
+            if (blocks.isEmpty()) return INVALID_ID
+
+            val tappedBlock = blocks.firstOrNull { it.bounds.contains(x.toInt(), y.toInt()) }
+            if (tappedBlock != null) return tappedBlock.id
+
+            val localY = (y.toInt() + scrollY - totalPaddingTop).coerceIn(0, layout.height - 1)
+            val line = layout.getLineForVertical(localY)
+            return blocks.firstOrNull { line in it.firstLine..it.lastLine }?.id ?: INVALID_ID
+        }
+
+        override fun getVisibleVirtualViews(virtualViewIds: MutableList<Int>) {
+            if (!isBlockLevelAccessibilityEnabled) return
+            val blocks = buildAccessibilityBlocks()
+            for (block in blocks) {
+                virtualViewIds += block.id
+            }
+        }
+
+        override fun onPopulateNodeForVirtualView(
+            virtualViewId: Int,
+            node: AccessibilityNodeInfoCompat,
+        ) {
+            if (!isBlockLevelAccessibilityEnabled) {
+                node.setBoundsInParent(Rect(0, 0, 1, 1))
+                node.isVisibleToUser = false
+                return
+            }
+            val block = buildAccessibilityBlocks().getOrNull(virtualViewId) ?: run {
+                node.setBoundsInParent(Rect(0, 0, 1, 1))
+                node.isVisibleToUser = false
+                return
+            }
+
+            node.className = AppCompatTextView::class.java.name
+            node.packageName = context.packageName
+            node.setBoundsInParent(block.bounds)
+            node.text = block.text
+            node.contentDescription = block.text
+            node.isFocusable = true
+            node.isVisibleToUser = block.bounds.bottom > 0 && block.bounds.top < height
+            if (onBlockClick != null) {
+                node.isClickable = true
+                node.addAction(AccessibilityNodeInfoCompat.ACTION_CLICK)
+            }
+        }
+
+        override fun onPerformActionForVirtualView(
+            virtualViewId: Int,
+            action: Int,
+            arguments: android.os.Bundle?,
+        ): Boolean {
+            if (!isBlockLevelAccessibilityEnabled) return false
+            if (action == AccessibilityNodeInfoCompat.ACTION_CLICK && onBlockClick != null) {
+                onBlockClick?.invoke()
+                sendEventForVirtualView(virtualViewId, AccessibilityEvent.TYPE_VIEW_CLICKED)
+                return true
+            }
+            return false
         }
     }
 }

--- a/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/CustomTextView.kt
+++ b/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/CustomTextView.kt
@@ -358,9 +358,10 @@ class CustomTextView : AppCompatTextView {
     private fun buildAccessibilityBlocks(): List<AccessibilityBlock> {
         val layout = layout ?: return emptyList()
         val content = text?.toString().orEmpty()
-        if (content.isBlank() || layout.lineCount == 0) return emptyList()
+        if (content.isEmpty() || layout.lineCount == 0) return emptyList()
 
         val blocks = mutableListOf<AccessibilityBlock>()
+        val spanned = text as? Spanned
         var runStartLine = -1
         var runStartOffset = -1
 
@@ -379,9 +380,11 @@ class CustomTextView : AppCompatTextView {
 
         fun closeRun(lastLine: Int, runEndOffset: Int) {
             if (runStartLine == -1 || runStartOffset == -1) return
+            val safeStartOffset = runStartOffset.coerceIn(0, content.length)
             val safeEndOffset = runEndOffset.coerceIn(0, content.length)
-            val blockText = content.substring(runStartOffset.coerceIn(0, safeEndOffset), safeEndOffset).trim()
-            if (blockText.isBlank()) {
+            val rawBlockText = content.substring(safeStartOffset.coerceIn(0, safeEndOffset), safeEndOffset)
+            val blockText = blockTextForAccessibility(rawBlockText, safeStartOffset, safeEndOffset)
+            if (blockText.isEmpty()) {
                 runStartLine = -1
                 runStartOffset = -1
                 return
@@ -404,17 +407,44 @@ class CustomTextView : AppCompatTextView {
         }
 
         for (line in 0 until layout.lineCount) {
+            val lineStart = layout.getLineStart(line).coerceIn(0, content.length)
+            val lineEnd = layout.getLineEnd(line).coerceIn(0, content.length)
+            val tableRowSpan = spanned
+                ?.getSpans(lineStart, lineEnd, TableRowSpan::class.java)
+                ?.firstOrNull()
+
+            if (tableRowSpan != null) {
+                closeRun(
+                    lastLine = line - 1,
+                    runEndOffset = lineStart,
+                )
+
+                blocks += AccessibilityBlock(
+                    id = blocks.size,
+                    firstLine = line,
+                    lastLine = line,
+                    bounds = Rect(
+                        (totalPaddingLeft - scrollX).coerceAtLeast(0),
+                        (totalPaddingTop + layout.getLineTop(line) - scrollY).coerceAtLeast(0),
+                        (width - totalPaddingRight - scrollX).coerceAtLeast(1),
+                        (totalPaddingTop + layout.getLineBottom(line) - scrollY).coerceAtLeast(1)
+                    ),
+                    text = tableRowTextForAccessibility(tableRowSpan),
+                )
+                continue
+            }
+
             if (isLineBlank(line)) {
                 closeRun(
                     lastLine = line - 1,
-                    runEndOffset = layout.getLineStart(line).coerceIn(0, content.length),
+                    runEndOffset = lineStart,
                 )
                 continue
             }
 
             if (runStartLine == -1) {
                 runStartLine = line
-                runStartOffset = layout.getLineStart(line).coerceIn(0, content.length)
+                runStartOffset = lineStart
             }
 
             if (lineEndsWithExplicitNewline(line) && line < layout.lineCount - 1) {
@@ -436,34 +466,68 @@ class CustomTextView : AppCompatTextView {
         return blocks
     }
 
+    private fun tableRowTextForAccessibility(tableRowSpan: TableRowSpan): String {
+        val cellWidth = tableRowSpan.cellWidth()
+        if (cellWidth <= 0) return "Table row"
+
+        val cells = mutableListOf<String>()
+        var cellOffset = 0
+        while (cellOffset < width) {
+            val cellLayout = tableRowSpan.findLayoutForHorizontalOffset(cellOffset) ?: break
+            cells += cellLayout.text.toString().trim()
+            cellOffset += cellWidth
+        }
+        return cells.filter { it.isNotEmpty() }.joinToString(", ").ifEmpty { "Table row" }
+    }
+
+    private fun blockTextForAccessibility(rawText: String, startOffset: Int, endOffset: Int): String {
+        val trimmed = rawText.trim()
+        if (trimmed.isNotEmpty()) return trimmed
+
+        val spanned = text as? Spanned ?: return ""
+        if (spanned.getSpans(startOffset, endOffset, TableRowSpan::class.java).isNotEmpty() ||
+            spanned.getSpans(startOffset, endOffset, TableSpan::class.java).isNotEmpty()
+        ) {
+            return "Table row"
+        }
+        if (spanned.getSpans(startOffset, endOffset, CodeBlockSpan::class.java).isNotEmpty()) {
+            return "Code block"
+        }
+        if (spanned.getSpans(startOffset, endOffset, BlockQuoteSpan::class.java).isNotEmpty()) {
+            return "Block quote"
+        }
+        return ""
+    }
+
+    private fun shouldUseVirtualBlockAccessibility(blocks: List<AccessibilityBlock>): Boolean {
+        if (!isBlockLevelAccessibilityEnabled) return false
+        return blocks.isNotEmpty()
+    }
+
     private inner class BlockAccessibilityHelper(host: CustomTextView) : ExploreByTouchHelper(host) {
 
         override fun onPopulateNodeForHost(node: AccessibilityNodeInfoCompat) {
             super.onPopulateNodeForHost(node)
-            if (!isBlockLevelAccessibilityEnabled) {
-                return
+            val blocks = buildAccessibilityBlocks()
+            if (shouldUseVirtualBlockAccessibility(blocks)) {
+                node.text = null
+                node.contentDescription = null
+                node.className = android.view.View::class.java.name
+                node.isFocusable = false
+                node.isClickable = false
+                node.isScreenReaderFocusable = false
             }
-            // Keep host as a container so TalkBack traverses virtual block children instead of
-            // announcing one giant TextView node first.
-            node.text = null
-            node.contentDescription = null
-            node.className = android.view.View::class.java.name
-            node.isFocusable = false
-            node.isClickable = false
-            node.isScreenReaderFocusable = false
         }
 
         override fun getVirtualViewAt(x: Float, y: Float): Int {
-            if (!isBlockLevelAccessibilityEnabled) return INVALID_ID
+            val blocks = buildAccessibilityBlocks()
+            if (!shouldUseVirtualBlockAccessibility(blocks)) return INVALID_ID
             if (x < 0f || y < 0f || x >= width.toFloat() || y >= height.toFloat()) {
                 return INVALID_ID
             }
 
             val layout = layout ?: return INVALID_ID
             if (layout.height <= 0) return INVALID_ID
-
-            val blocks = buildAccessibilityBlocks()
-            if (blocks.isEmpty()) return INVALID_ID
 
             val tappedBlock = blocks.firstOrNull { it.bounds.contains(x.toInt(), y.toInt()) }
             if (tappedBlock != null) return tappedBlock.id
@@ -474,8 +538,8 @@ class CustomTextView : AppCompatTextView {
         }
 
         override fun getVisibleVirtualViews(virtualViewIds: MutableList<Int>) {
-            if (!isBlockLevelAccessibilityEnabled) return
             val blocks = buildAccessibilityBlocks()
+            if (!shouldUseVirtualBlockAccessibility(blocks)) return
             for (block in blocks) {
                 virtualViewIds += block.id
             }
@@ -485,13 +549,16 @@ class CustomTextView : AppCompatTextView {
             virtualViewId: Int,
             node: AccessibilityNodeInfoCompat,
         ) {
-            if (!isBlockLevelAccessibilityEnabled) {
+            val blocks = buildAccessibilityBlocks()
+            if (!shouldUseVirtualBlockAccessibility(blocks)) {
                 node.setBoundsInParent(Rect(0, 0, 1, 1))
+                node.contentDescription = ""
                 node.isVisibleToUser = false
                 return
             }
-            val block = buildAccessibilityBlocks().getOrNull(virtualViewId) ?: run {
+            val block = blocks.firstOrNull { it.id == virtualViewId } ?: run {
                 node.setBoundsInParent(Rect(0, 0, 1, 1))
+                node.contentDescription = ""
                 node.isVisibleToUser = false
                 return
             }
@@ -514,7 +581,9 @@ class CustomTextView : AppCompatTextView {
             action: Int,
             arguments: android.os.Bundle?,
         ): Boolean {
-            if (!isBlockLevelAccessibilityEnabled) return false
+            val blocks = buildAccessibilityBlocks()
+            if (!shouldUseVirtualBlockAccessibility(blocks)) return false
+            if (blocks.none { it.id == virtualViewId }) return false
             if (action == AccessibilityNodeInfoCompat.ACTION_CLICK && onBlockClick != null) {
                 onBlockClick?.invoke()
                 sendEventForVirtualView(virtualViewId, AccessibilityEvent.TYPE_VIEW_CLICKED)

--- a/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/CustomTextView.kt
+++ b/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/CustomTextView.kt
@@ -25,6 +25,8 @@ import io.noties.markwon.core.spans.CodeBlockSpan
 import io.noties.markwon.ext.tables.TableRowSpan
 import io.noties.markwon.ext.tables.TableSpan
 import kotlin.math.ceil
+import kotlin.math.max
+import kotlin.math.min
 
 /**
  * This View contains a hack of the original TextView to fix the sizing issue of multiline text.
@@ -59,7 +61,8 @@ class CustomTextView : AppCompatTextView {
         val firstLine: Int,
         val lastLine: Int,
         val bounds: Rect,
-        val text: String,
+        val text: CharSequence,
+        val clickableSpan: ClickableSpan? = null,
     )
 
     init {
@@ -323,7 +326,9 @@ class CustomTextView : AppCompatTextView {
     }
 
     fun setLinkClicksEnabled(enabled: Boolean) {
+        if (areLinkClicksEnabled == enabled) return
         areLinkClicksEnabled = enabled
+        blockAccessibilityHelper?.invalidateRoot()
     }
 
     fun setBlockLevelAccessibilityEnabled(enabled: Boolean) {
@@ -418,19 +423,7 @@ class CustomTextView : AppCompatTextView {
                     lastLine = line - 1,
                     runEndOffset = lineStart,
                 )
-
-                blocks += AccessibilityBlock(
-                    id = blocks.size,
-                    firstLine = line,
-                    lastLine = line,
-                    bounds = Rect(
-                        (totalPaddingLeft - scrollX).coerceAtLeast(0),
-                        (totalPaddingTop + layout.getLineTop(line) - scrollY).coerceAtLeast(0),
-                        (width - totalPaddingRight - scrollX).coerceAtLeast(1),
-                        (totalPaddingTop + layout.getLineBottom(line) - scrollY).coerceAtLeast(1)
-                    ),
-                    text = tableRowTextForAccessibility(tableRowSpan),
-                )
+                addTableAccessibilityBlocks(blocks, layout, line, tableRowSpan)
                 continue
             }
 
@@ -466,18 +459,135 @@ class CustomTextView : AppCompatTextView {
         return blocks
     }
 
-    private fun tableRowTextForAccessibility(tableRowSpan: TableRowSpan): String {
+    private fun addTableAccessibilityBlocks(
+        blocks: MutableList<AccessibilityBlock>,
+        layout: Layout,
+        line: Int,
+        tableRowSpan: TableRowSpan,
+    ) {
         val cellWidth = tableRowSpan.cellWidth()
-        if (cellWidth <= 0) return "Table row"
-
-        val cells = mutableListOf<String>()
-        var cellOffset = 0
-        while (cellOffset < width) {
-            val cellLayout = tableRowSpan.findLayoutForHorizontalOffset(cellOffset) ?: break
-            cells += cellLayout.text.toString().trim()
-            cellOffset += cellWidth
+        if (cellWidth <= 0) {
+            blocks += AccessibilityBlock(
+                id = blocks.size,
+                firstLine = line,
+                lastLine = line,
+                bounds = tableRowBounds(layout, line),
+                text = "Table row",
+            )
+            return
         }
-        return cells.filter { it.isNotEmpty() }.joinToString(", ").ifEmpty { "Table row" }
+
+        var cellIndex = 0
+        while (true) {
+            val cellLayout = tableRowSpan.findLayoutForHorizontalOffset(cellIndex * cellWidth) ?: break
+            val cellText = cellLayout.text
+            val spannedCellText = cellText as? Spanned
+            val cellBounds = tableCellBounds(layout, line, cellIndex, cellWidth)
+            val clickableSpans = if (areLinkClicksEnabled) {
+                spannedCellText
+                    ?.getSpans(0, cellText.length, ClickableSpan::class.java)
+                    ?.sortedBy { spannedCellText.getSpanStart(it) }
+                    .orEmpty()
+            } else {
+                emptyList()
+            }
+
+            val trimmedStart = cellText.indexOfFirst { !it.isWhitespace() }
+            val trimmedEnd = cellText.indexOfLast { !it.isWhitespace() } + 1
+            val singleLinkCoversCell = clickableSpans.singleOrNull()?.let {
+                trimmedStart >= 0 &&
+                    (spannedCellText?.getSpanStart(it) ?: Int.MAX_VALUE) <= trimmedStart &&
+                    (spannedCellText?.getSpanEnd(it) ?: Int.MIN_VALUE) >= trimmedEnd
+            } == true
+
+            if (!singleLinkCoversCell) {
+                val label = cellText.toString().trim()
+                if (label.isNotEmpty()) {
+                    blocks += AccessibilityBlock(
+                        id = blocks.size,
+                        firstLine = line,
+                        lastLine = line,
+                        bounds = cellBounds,
+                        text = label,
+                    )
+                }
+            }
+
+            for (clickableSpan in clickableSpans) {
+                val spanStart = spannedCellText?.getSpanStart(clickableSpan) ?: continue
+                val spanEnd = spannedCellText.getSpanEnd(clickableSpan)
+                if (spanStart < 0 || spanEnd <= spanStart) continue
+
+                blocks += AccessibilityBlock(
+                    id = blocks.size,
+                    firstLine = line,
+                    lastLine = line,
+                    bounds = tableLinkBounds(cellLayout, cellBounds, spanStart, spanEnd),
+                    text = cellText.subSequence(spanStart, spanEnd).toString(),
+                    clickableSpan = clickableSpan,
+                )
+            }
+            cellIndex++
+        }
+    }
+
+    private fun tableRowBounds(layout: Layout, line: Int): Rect {
+        val left = (totalPaddingLeft - scrollX).coerceAtLeast(0)
+        val right = (width - totalPaddingRight - scrollX).coerceAtLeast(left + 1)
+        val top = (totalPaddingTop + layout.getLineTop(line) - scrollY).coerceAtLeast(0)
+        val bottom = (totalPaddingTop + layout.getLineBottom(line) - scrollY).coerceAtLeast(top + 1)
+        return Rect(left, top, right, bottom)
+    }
+
+    private fun tableCellBounds(layout: Layout, line: Int, cellIndex: Int, cellWidth: Int): Rect {
+        val rowBounds = tableRowBounds(layout, line)
+        val left = (rowBounds.left + cellIndex * cellWidth).coerceAtMost(rowBounds.right - 1)
+        val right = (left + cellWidth).coerceAtMost(rowBounds.right).coerceAtLeast(left + 1)
+        return Rect(left, rowBounds.top, right, rowBounds.bottom)
+    }
+
+    private fun tableLinkBounds(
+        cellLayout: Layout,
+        cellBounds: Rect,
+        spanStart: Int,
+        spanEnd: Int,
+    ): Rect {
+        val safeStart = spanStart.coerceIn(0, cellLayout.text.length)
+        val safeEnd = spanEnd.coerceIn(safeStart + 1, cellLayout.text.length)
+        val firstLine = cellLayout.getLineForOffset(safeStart)
+        val lastLine = cellLayout.getLineForOffset(safeEnd - 1)
+        var left = Float.MAX_VALUE
+        var right = -Float.MAX_VALUE
+
+        for (line in firstLine..lastLine) {
+            val lineStart = cellLayout.getLineStart(line)
+            val lineEnd = cellLayout.getLineEnd(line)
+            val segmentStart = max(safeStart, lineStart)
+            val segmentEnd = min(safeEnd, lineEnd)
+            val startX = if (segmentStart == lineStart) {
+                cellLayout.getLineLeft(line)
+            } else {
+                cellLayout.getPrimaryHorizontal(segmentStart)
+            }
+            val endX = if (segmentEnd == lineEnd) {
+                cellLayout.getLineRight(line)
+            } else {
+                cellLayout.getPrimaryHorizontal(segmentEnd)
+            }
+            left = min(left, min(startX, endX))
+            right = max(right, max(startX, endX))
+        }
+
+        val horizontalInset = ((cellBounds.width() - cellLayout.width) / 2).coerceAtLeast(0)
+        val verticalInset = ((cellBounds.height() - cellLayout.height) / 2).coerceAtLeast(0)
+        val linkBounds = Rect(
+            cellBounds.left + horizontalInset + left.toInt(),
+            cellBounds.top + verticalInset + cellLayout.getLineTop(firstLine),
+            cellBounds.left + horizontalInset + right.toInt(),
+            cellBounds.top + verticalInset + cellLayout.getLineBottom(lastLine),
+        )
+        if (!linkBounds.intersect(cellBounds)) return cellBounds
+        return if (linkBounds.width() > 0 && linkBounds.height() > 0) linkBounds else cellBounds
     }
 
     private fun blockTextForAccessibility(rawText: String, startOffset: Int, endOffset: Int): String {
@@ -529,7 +639,9 @@ class CustomTextView : AppCompatTextView {
             val layout = layout ?: return INVALID_ID
             if (layout.height <= 0) return INVALID_ID
 
-            val tappedBlock = blocks.firstOrNull { it.bounds.contains(x.toInt(), y.toInt()) }
+            val tappedBlock = blocks.firstOrNull {
+                it.clickableSpan != null && it.bounds.contains(x.toInt(), y.toInt())
+            } ?: blocks.firstOrNull { it.bounds.contains(x.toInt(), y.toInt()) }
             if (tappedBlock != null) return tappedBlock.id
 
             val localY = (y.toInt() + scrollY - totalPaddingTop).coerceIn(0, layout.height - 1)
@@ -567,10 +679,13 @@ class CustomTextView : AppCompatTextView {
             node.packageName = context.packageName
             node.setBoundsInParent(block.bounds)
             node.text = block.text
-            node.contentDescription = block.text
             node.isFocusable = true
             node.isVisibleToUser = block.bounds.bottom > 0 && block.bounds.top < height
-            if (onBlockClick != null) {
+            if (block.clickableSpan != null && areLinkClicksEnabled) {
+                node.roleDescription = "link"
+                node.isClickable = true
+                node.addAction(AccessibilityNodeInfoCompat.ACTION_CLICK)
+            } else if (onBlockClick != null) {
                 node.isClickable = true
                 node.addAction(AccessibilityNodeInfoCompat.ACTION_CLICK)
             }
@@ -583,8 +698,15 @@ class CustomTextView : AppCompatTextView {
         ): Boolean {
             val blocks = buildAccessibilityBlocks()
             if (!shouldUseVirtualBlockAccessibility(blocks)) return false
-            if (blocks.none { it.id == virtualViewId }) return false
-            if (action == AccessibilityNodeInfoCompat.ACTION_CLICK && onBlockClick != null) {
+            val block = blocks.firstOrNull { it.id == virtualViewId } ?: return false
+            if (action != AccessibilityNodeInfoCompat.ACTION_CLICK) return false
+
+            if (block.clickableSpan != null && areLinkClicksEnabled) {
+                block.clickableSpan.onClick(this@CustomTextView)
+                sendEventForVirtualView(virtualViewId, AccessibilityEvent.TYPE_VIEW_CLICKED)
+                return true
+            }
+            if (onBlockClick != null) {
                 onBlockClick?.invoke()
                 sendEventForVirtualView(virtualViewId, AccessibilityEvent.TYPE_VIEW_CLICKED)
                 return true

--- a/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/MarkdownText.kt
+++ b/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/MarkdownText.kt
@@ -52,13 +52,13 @@ fun MarkdownText(
     headingBreakColor: Color = Color.Transparent,
     enableUnderlineForLink: Boolean = true,
     importForAccessibility: Int = View.IMPORTANT_FOR_ACCESSIBILITY_AUTO,
-    enableBlockLevelAccessibility: Boolean = false,
     /** Enables text wrapping. See https://github.com/jeziellago/compose-markdown/pull/157 */
     wrapMultilineTextWidth: Boolean = false,
     beforeSetMarkdown: ((TextView, Spanned) -> Unit)? = null,
     afterSetMarkdown: ((TextView) -> Unit)? = null,
     onLinkClicked: ((String) -> Unit)? = null,
-    onTextLayout: ((numLines: Int) -> Unit)? = null
+    onTextLayout: ((numLines: Int) -> Unit)? = null,
+    enableBlockLevelAccessibility: Boolean = false,
 ) {
     val defaultColor: Color = LocalContentColor.current
     val context: Context = LocalContext.current

--- a/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/MarkdownText.kt
+++ b/markdowntext/src/main/java/dev/jeziellago/compose/markdowntext/MarkdownText.kt
@@ -52,6 +52,7 @@ fun MarkdownText(
     headingBreakColor: Color = Color.Transparent,
     enableUnderlineForLink: Boolean = true,
     importForAccessibility: Int = View.IMPORTANT_FOR_ACCESSIBILITY_AUTO,
+    enableBlockLevelAccessibility: Boolean = false,
     /** Enables text wrapping. See https://github.com/jeziellago/compose-markdown/pull/157 */
     wrapMultilineTextWidth: Boolean = false,
     beforeSetMarkdown: ((TextView, Spanned) -> Unit)? = null,
@@ -110,6 +111,7 @@ fun MarkdownText(
                     setTextIsSelectable(isTextSelectable)
                     setOnBlockClickListener(onClick)
                     setLinkClicksEnabled(!disableLinkMovementMethod)
+                    setBlockLevelAccessibilityEnabled(enableBlockLevelAccessibility)
 
                     movementMethod = if (disableLinkMovementMethod) {
                         null
@@ -155,6 +157,7 @@ fun MarkdownText(
                 textView.setTextIsSelectable(isTextSelectable)
                 textView.setOnBlockClickListener(onClick)
                 textView.setLinkClicksEnabled(!disableLinkMovementMethod)
+                textView.setBlockLevelAccessibilityEnabled(enableBlockLevelAccessibility)
                 markdownRender.setMarkdown(textView, markdown)
                 textView.movementMethod = if (disableLinkMovementMethod) {
                     null

--- a/markdowntext/src/test/java/dev/jeziellago/compose/markdowntext/CustomTextViewTest.kt
+++ b/markdowntext/src/test/java/dev/jeziellago/compose/markdowntext/CustomTextViewTest.kt
@@ -7,8 +7,11 @@ import android.text.Spannable
 import android.text.SpannableString
 import android.text.Spanned
 import android.text.style.ClickableSpan
+import android.text.util.Linkify
 import android.view.MotionEvent
 import android.view.View
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
 import androidx.core.view.accessibility.AccessibilityNodeInfoCompat
 import androidx.test.core.app.ApplicationProvider
 import io.noties.markwon.ext.tables.TableRowSpan
@@ -221,7 +224,7 @@ class CustomTextViewTest {
     }
 
     @Test
-    fun `test block accessibility builds table rows with cell text`() {
+    fun `test block accessibility builds individual table cells`() {
         val tableText = SpannableString("\u00a0\n\u00a0")
         tableText.setSpan(createTableRowSpan("Country", "Capital"), 0, 1, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
         tableText.setSpan(createTableRowSpan("Argentina", "Buenos Aires"), 2, 3, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
@@ -231,16 +234,96 @@ class CustomTextViewTest {
         measureAndLayoutTextView()
         textView.draw(Canvas(Bitmap.createBitmap(LAYOUT_WIDTH, LAYOUT_HEIGHT, Bitmap.Config.ARGB_8888)))
 
-        val buildBlocks = CustomTextView::class.java.getDeclaredMethod("buildAccessibilityBlocks")
-        buildBlocks.isAccessible = true
-        val blocks = buildBlocks.invoke(textView) as List<*>
+        val blocks = accessibilityBlocks()
         val textField = checkNotNull(blocks.firstOrNull()).javaClass.getDeclaredField("text")
         textField.isAccessible = true
 
         assertEquals(
-            listOf("Country, Capital", "Argentina, Buenos Aires"),
+            listOf("Country", "Capital", "Argentina", "Buenos Aires"),
             blocks.map { textField.get(it) },
         )
+    }
+
+    @Test
+    fun `test table accessibility activates explicit and bare URL links`() {
+        val clickedLinks = mutableListOf<String>()
+        val markwon = MarkdownRender.create(
+            context = context,
+            imageLoader = null,
+            linkifyMask = Linkify.WEB_URLS,
+            enableSoftBreakAddsNewLine = false,
+            syntaxHighlightColor = Color.LightGray,
+            syntaxHighlightTextColor = Color.Unspecified,
+            headingBreakColor = Color.Transparent,
+            enableUnderlineForLink = true,
+            onLinkClicked = clickedLinks::add,
+            style = TextStyle(),
+        )
+        markwon.setMarkdown(
+            textView,
+            """
+                | Type | Link |
+                |---|---|
+                | Bare | https://example.com/bare |
+                | Explicit | [Docs](https://example.com/docs) |
+            """.trimIndent(),
+        )
+        textView.setBlockLevelAccessibilityEnabled(true)
+        measureAndDrawTextView()
+        measureAndDrawTextView()
+
+        val blocks = accessibilityBlocks()
+        val blockClass = checkNotNull(blocks.firstOrNull()).javaClass
+        val textField = blockClass.getDeclaredField("text").apply { isAccessible = true }
+        val clickableSpanField = blockClass.getDeclaredField("clickableSpan").apply { isAccessible = true }
+        val idField = blockClass.getDeclaredField("id").apply { isAccessible = true }
+        val linkBlocks = blocks.filter { clickableSpanField.get(it) != null }
+        val linksByText = linkBlocks.associateBy { checkNotNull(textField.get(it)).toString() }
+
+        assertEquals(setOf("https://example.com/bare", "Docs"), linksByText.keys)
+
+        performAccessibilityClick(idField.getInt(linksByText.getValue("https://example.com/bare")))
+        performAccessibilityClick(idField.getInt(linksByText.getValue("Docs")))
+
+        assertEquals(
+            listOf("https://example.com/bare", "https://example.com/docs"),
+            clickedLinks,
+        )
+    }
+
+    @Test
+    fun `test table accessibility updates when link clicks are toggled`() {
+        val markwon = MarkdownRender.create(
+            context = context,
+            imageLoader = null,
+            linkifyMask = Linkify.WEB_URLS,
+            enableSoftBreakAddsNewLine = false,
+            syntaxHighlightColor = Color.LightGray,
+            syntaxHighlightTextColor = Color.Unspecified,
+            headingBreakColor = Color.Transparent,
+            enableUnderlineForLink = true,
+            onLinkClicked = {},
+            style = TextStyle(),
+        )
+        markwon.setMarkdown(
+            textView,
+            """
+                | Type | Link |
+                |---|---|
+                | Documentation | [Docs](https://example.com/docs) |
+            """.trimIndent(),
+        )
+        textView.setBlockLevelAccessibilityEnabled(true)
+        measureAndDrawTextView()
+        measureAndDrawTextView()
+
+        assertEquals(1, clickableAccessibilityBlockCount())
+
+        textView.setLinkClicksEnabled(false)
+        assertEquals(0, clickableAccessibilityBlockCount())
+
+        textView.setLinkClicksEnabled(true)
+        assertEquals(1, clickableAccessibilityBlockCount())
     }
 
     @Test
@@ -265,13 +348,51 @@ class CustomTextViewTest {
         assertEquals("", node.contentDescription)
     }
 
-    private fun createTableRowSpan(vararg cells: String): TableRowSpan {
+    private fun createTableRowSpan(vararg cells: CharSequence): TableRowSpan {
         return TableRowSpan(
             TableTheme.create(context),
             cells.map { TableRowSpan.Cell(TableRowSpan.ALIGN_LEFT, it) },
             false,
             false,
         )
+    }
+
+    private fun accessibilityBlocks(): List<*> {
+        val buildBlocks = CustomTextView::class.java.getDeclaredMethod("buildAccessibilityBlocks")
+        buildBlocks.isAccessible = true
+        return buildBlocks.invoke(textView) as List<*>
+    }
+
+    private fun clickableAccessibilityBlockCount(): Int {
+        val blocks = accessibilityBlocks()
+        val clickableSpanField = checkNotNull(blocks.firstOrNull())
+            .javaClass
+            .getDeclaredField("clickableSpan")
+            .apply { isAccessible = true }
+        return blocks.count { clickableSpanField.get(it) != null }
+    }
+
+    private fun performAccessibilityClick(virtualViewId: Int) {
+        val helperField = CustomTextView::class.java.getDeclaredField("blockAccessibilityHelper")
+        helperField.isAccessible = true
+        val helper = checkNotNull(helperField.get(textView))
+        val performAction = helper.javaClass.getDeclaredMethod(
+            "onPerformActionForVirtualView",
+            Int::class.javaPrimitiveType,
+            Int::class.javaPrimitiveType,
+            android.os.Bundle::class.java,
+        )
+        performAction.isAccessible = true
+
+        assertEquals(
+            true,
+            performAction.invoke(helper, virtualViewId, AccessibilityNodeInfoCompat.ACTION_CLICK, null),
+        )
+    }
+
+    private fun measureAndDrawTextView() {
+        measureAndLayoutTextView()
+        textView.draw(Canvas(Bitmap.createBitmap(LAYOUT_WIDTH, LAYOUT_HEIGHT, Bitmap.Config.ARGB_8888)))
     }
 
     private fun measureAndLayoutTextView() {

--- a/markdowntext/src/test/java/dev/jeziellago/compose/markdowntext/CustomTextViewTest.kt
+++ b/markdowntext/src/test/java/dev/jeziellago/compose/markdowntext/CustomTextViewTest.kt
@@ -1,12 +1,20 @@
 package dev.jeziellago.compose.markdowntext
 
 import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Canvas
 import android.text.Spannable
 import android.text.SpannableString
+import android.text.Spanned
 import android.text.style.ClickableSpan
 import android.view.MotionEvent
 import android.view.View
+import androidx.core.view.accessibility.AccessibilityNodeInfoCompat
 import androidx.test.core.app.ApplicationProvider
+import io.noties.markwon.ext.tables.TableRowSpan
+import io.noties.markwon.ext.tables.TableSpan
+import io.noties.markwon.ext.tables.TableTheme
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -210,6 +218,60 @@ class CustomTextViewTest {
 
         assert(!linkClicked) { "Disabled link clicks should not trigger clickable spans" }
         assert(blockClicked) { "Disabled link clicks should fall through to the block click callback" }
+    }
+
+    @Test
+    fun `test block accessibility builds table rows with cell text`() {
+        val tableText = SpannableString("\u00a0\n\u00a0")
+        tableText.setSpan(createTableRowSpan("Country", "Capital"), 0, 1, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+        tableText.setSpan(createTableRowSpan("Argentina", "Buenos Aires"), 2, 3, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+        tableText.setSpan(TableSpan(), 0, tableText.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+        textView.text = tableText
+        textView.setBlockLevelAccessibilityEnabled(true)
+        measureAndLayoutTextView()
+        textView.draw(Canvas(Bitmap.createBitmap(LAYOUT_WIDTH, LAYOUT_HEIGHT, Bitmap.Config.ARGB_8888)))
+
+        val buildBlocks = CustomTextView::class.java.getDeclaredMethod("buildAccessibilityBlocks")
+        buildBlocks.isAccessible = true
+        val blocks = buildBlocks.invoke(textView) as List<*>
+        val textField = checkNotNull(blocks.firstOrNull()).javaClass.getDeclaredField("text")
+        textField.isAccessible = true
+
+        assertEquals(
+            listOf("Country, Capital", "Argentina, Buenos Aires"),
+            blocks.map { textField.get(it) },
+        )
+    }
+
+    @Test
+    fun `test stale accessibility block remains a valid hidden node`() {
+        textView.text = "Paragraph"
+        textView.setBlockLevelAccessibilityEnabled(true)
+        measureAndLayoutTextView()
+
+        val helperField = CustomTextView::class.java.getDeclaredField("blockAccessibilityHelper")
+        helperField.isAccessible = true
+        val helper = checkNotNull(helperField.get(textView))
+        val populateNode = helper.javaClass.getDeclaredMethod(
+            "onPopulateNodeForVirtualView",
+            Int::class.javaPrimitiveType,
+            AccessibilityNodeInfoCompat::class.java,
+        )
+        populateNode.isAccessible = true
+        val node = AccessibilityNodeInfoCompat.obtain()
+
+        populateNode.invoke(helper, 999, node)
+
+        assertEquals("", node.contentDescription)
+    }
+
+    private fun createTableRowSpan(vararg cells: String): TableRowSpan {
+        return TableRowSpan(
+            TableTheme.create(context),
+            cells.map { TableRowSpan.Cell(TableRowSpan.ALIGN_LEFT, it) },
+            false,
+            false,
+        )
     }
 
     private fun measureAndLayoutTextView() {

--- a/sample/src/main/java/dev/jeziellago/compose/markdown/MainActivity.kt
+++ b/sample/src/main/java/dev/jeziellago/compose/markdown/MainActivity.kt
@@ -432,6 +432,42 @@ private fun SampleMarkdown() {
                         )
                     }
                 }
+
+                item {
+                    MarkdownText(
+                        modifier = Modifier
+                            .padding(8.dp)
+                            .fillMaxWidth(),
+                        enableBlockLevelAccessibility = false,
+                        markdown = """
+                            ## Block-Level Accessibility Disabled
+                            
+                            First paragraph: TalkBack will see this entire block as one single node.
+                            
+                            Second paragraph: Even though there are multiple paragraphs here, accessibility services will announce them together.
+                            
+                            Third paragraph: This is the default behavior for compatibility with existing apps.
+                        """.trimIndent()
+                    )
+                }
+
+                item {
+                    MarkdownText(
+                        modifier = Modifier
+                            .padding(8.dp)
+                            .fillMaxWidth(),
+                        enableBlockLevelAccessibility = true,
+                        markdown = """
+                            ## Block-Level Accessibility Enabled
+                            
+                            First paragraph: TalkBack will now see this as a separate block and allow you to navigate to it individually.
+                            
+                            Second paragraph: Each paragraph becomes its own accessibility node that TalkBack can focus on.
+                            
+                            Third paragraph: This makes navigation much easier for users with screen readers when dealing with longer markdown documents.
+                        """.trimIndent()
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
# Issue

when we display a large text with multiple paragraphs in the Markdown component TalkBack will always read the text as a whole, not able to select individual paragraphs.

# Solution 

I implemented virtual accessibility children in CustomTextView using ExploreByTouchHelper to expose individual text blocks as separate TalkBack nodes instead of one giant node. Added a toggle flag enableBlockLevelAccessibility (default: false) so users can opt-in to per-block navigation without breaking existing behavior.

# QA

1. enable [talkback](https://support.google.com/accessibility/android/answer/6007100?hl=en) on device;
2. navigate to the bottom of the sample app;
3. explore the last two elements of the sample page.

old behavior: the accessibility is only able to read the whole paragraph as a single node;
expected behavior: user is able to select individual paragraphs.